### PR TITLE
Feat: 문해력 진단 - 지문 (목록,개별) 조회

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,8 +31,8 @@ dependencies {
 	//database
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	runtimeOnly 'com.h2database:h2'
+	implementation 'com.mysql:mysql-connector-j'
+	implementation 'com.h2database:h2'
 
 	//thymeleaf
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
@@ -53,6 +53,6 @@ tasks.named('bootBuildImage') {
 	builder = 'paketobuildpacks/builder-jammy-base:latest'
 }
 
-test {
+tasks.named('test') {
 	useJUnitPlatform()
 }

--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,6 @@ tasks.named('bootBuildImage') {
 	builder = 'paketobuildpacks/builder-jammy-base:latest'
 }
 
-tasks.named('test') {
+test {
 	useJUnitPlatform()
 }

--- a/src/main/java/com/knu/KnowcKKnowcK/controller/articleSummary/LoadArticlesController.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/controller/articleSummary/LoadArticlesController.java
@@ -1,0 +1,31 @@
+package com.knu.KnowcKKnowcK.controller.articleSummary;
+
+import com.knu.KnowcKKnowcK.domain.Article;
+import com.knu.KnowcKKnowcK.service.articleSummary.LoadArticlesService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class LoadArticlesController {
+
+    @Autowired
+    LoadArticlesService loadArticlesService;
+
+    @Operation(summary = "지문 목록 조회", description = "문해력 진단을 할 지문 목록을 조회한다.")
+    @ApiResponses({@ApiResponse(responseCode = "200", description = "지문 목록 조회 성공"),
+                    @ApiResponse(responseCode = "400", description = "지문 목록 조회 실패")})
+    @GetMapping("/api/article/list")
+    ResponseEntity<List<Article>> loadArticles(){
+
+        return ResponseEntity.ok(loadArticlesService.loadArticles());
+    }
+}

--- a/src/main/java/com/knu/KnowcKKnowcK/controller/articleSummary/LoadArticlesController.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/controller/articleSummary/LoadArticlesController.java
@@ -9,9 +9,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+import java.util.Optional;
 
 @RestController
 @RequiredArgsConstructor
@@ -28,4 +30,13 @@ public class LoadArticlesController {
 
         return ResponseEntity.ok(loadArticlesService.loadArticles());
     }
+
+    @Operation(summary = "지문 개별 조회", description = "문해력 진단을 할 지문 1개를 id로 조회한다.")
+    @ApiResponses({@ApiResponse(responseCode = "200", description = "지문 조회 성공"),
+            @ApiResponse(responseCode = "400", description = "지문 조회 실패")})
+    @GetMapping("/api/article/{articleId}")
+    ResponseEntity<Optional<Article>> loadArticleById(@PathVariable Long articleId){
+        return ResponseEntity.ok((loadArticlesService.loadArticleById(articleId)));
+    }
+
 }

--- a/src/main/java/com/knu/KnowcKKnowcK/repository/ArticleRepository.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/repository/ArticleRepository.java
@@ -3,7 +3,10 @@ package com.knu.KnowcKKnowcK.repository;
 import com.knu.KnowcKKnowcK.domain.Article;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ArticleRepository extends JpaRepository<Article, Long> {
 
-
+    @Override
+    Optional<Article> findById(Long id);
 }

--- a/src/main/java/com/knu/KnowcKKnowcK/repository/ArticleRepository.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/repository/ArticleRepository.java
@@ -1,0 +1,9 @@
+package com.knu.KnowcKKnowcK.repository;
+
+import com.knu.KnowcKKnowcK.domain.Article;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ArticleRepository extends JpaRepository<Article, Long> {
+
+
+}

--- a/src/main/java/com/knu/KnowcKKnowcK/service/articleSummary/LoadArticlesService.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/service/articleSummary/LoadArticlesService.java
@@ -3,9 +3,12 @@ package com.knu.KnowcKKnowcK.service.articleSummary;
 import com.knu.KnowcKKnowcK.domain.Article;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface LoadArticlesService {
 
     List<Article>  loadArticles();
+
+    Optional<Article> loadArticleById(Long id);
 
 }

--- a/src/main/java/com/knu/KnowcKKnowcK/service/articleSummary/LoadArticlesService.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/service/articleSummary/LoadArticlesService.java
@@ -1,0 +1,11 @@
+package com.knu.KnowcKKnowcK.service.articleSummary;
+
+import com.knu.KnowcKKnowcK.domain.Article;
+
+import java.util.List;
+
+public interface LoadArticlesService {
+
+    List<Article>  loadArticles();
+
+}

--- a/src/main/java/com/knu/KnowcKKnowcK/service/articleSummary/LoadArticlesServiceImpl.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/service/articleSummary/LoadArticlesServiceImpl.java
@@ -1,0 +1,22 @@
+package com.knu.KnowcKKnowcK.service.articleSummary;
+
+import com.knu.KnowcKKnowcK.domain.Article;
+import com.knu.KnowcKKnowcK.repository.ArticleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class LoadArticlesServiceImpl implements LoadArticlesService{
+
+    @Autowired
+    private final ArticleRepository articleRepository;
+
+    @Override
+    public List<Article> loadArticles() {
+        return articleRepository.findAll();
+    }
+}

--- a/src/main/java/com/knu/KnowcKKnowcK/service/articleSummary/LoadArticlesServiceImpl.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/service/articleSummary/LoadArticlesServiceImpl.java
@@ -3,7 +3,6 @@ package com.knu.KnowcKKnowcK.service.articleSummary;
 import com.knu.KnowcKKnowcK.domain.Article;
 import com.knu.KnowcKKnowcK.repository.ArticleRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -13,7 +12,6 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class LoadArticlesServiceImpl implements LoadArticlesService{
 
-    @Autowired
     private final ArticleRepository articleRepository;
 
     @Override

--- a/src/main/java/com/knu/KnowcKKnowcK/service/articleSummary/LoadArticlesServiceImpl.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/service/articleSummary/LoadArticlesServiceImpl.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -18,5 +19,10 @@ public class LoadArticlesServiceImpl implements LoadArticlesService{
     @Override
     public List<Article> loadArticles() {
         return articleRepository.findAll();
+    }
+
+    @Override
+    public Optional<Article> loadArticleById(Long id) {
+        return articleRepository.findById(id);
     }
 }

--- a/src/main/resources/articleExample.sql
+++ b/src/main/resources/articleExample.sql
@@ -1,0 +1,14 @@
+INSERT INTO Article (category, title, content, created_Time, article_Url)
+VALUES ('Tech', 'How to use Java Streams', 'Java Streams provide a powerful way to process collections of objects. Here is a tutorial on how to use them effectively.', '2023-03-20 10:15:00', 'https://example.com/java-streams-tutorial');
+
+INSERT INTO Article (category, title, content, created_Time, article_Url)
+VALUES ('Science', 'The Theory of Relativity', 'Albert Einsteins theory of relativity revolutionized our understanding of space, time, and gravity. Learn more about it here.', '2023-03-21 14:30:00', 'https://example.com/theory-of-relativity');
+
+INSERT INTO Article (category, title, content, created_Time, article_Url)
+VALUES ('Health', '10 Tips for Better Sleep', 'Quality sleep is essential for overall health and well-being. Here are 10 tips to improve your sleep hygiene and get better rest.', '2023-03-22 08:45:00', 'https://example.com/sleep-tips');
+
+INSERT INTO Article (category, title, content, created_Time, article_Url)
+VALUES ('Business', 'Effective Communication Strategies', 'Communication is key in business. Learn effective communication strategies to improve collaboration and productivity in your team.', '2023-03-23 12:00:00', 'https://example.com/communication-strategies');
+
+INSERT INTO Article (category, title, content, created_Time, article_Url)
+VALUES ('Food', 'Healthy Smoothie Recipes', 'Smoothies are a delicious and nutritious way to start your day. Try these healthy smoothie recipes packed with fruits and vegetables.', '2023-03-24 09:30:00', 'https://example.com/healthy-smoothie-recipes');

--- a/src/test/java/com/knu/KnowcKKnowcK/controller/articleSummary/LoadArticlesControllerTest.java
+++ b/src/test/java/com/knu/KnowcKKnowcK/controller/articleSummary/LoadArticlesControllerTest.java
@@ -35,7 +35,7 @@ class LoadArticlesControllerTest {
     @DisplayName("id에 맞는 지문 1개를 조회한다.")
     void loadArticleById() throws Exception{
 
-        Long articleId = 1L;
+        Long articleId = 2L;
         mockMvc.perform(MockMvcRequestBuilders.get("/api/article/{articleId}", articleId)).andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("id").value(articleId))

--- a/src/test/java/com/knu/KnowcKKnowcK/controller/articleSummary/LoadArticlesControllerTest.java
+++ b/src/test/java/com/knu/KnowcKKnowcK/controller/articleSummary/LoadArticlesControllerTest.java
@@ -3,12 +3,10 @@ package com.knu.KnowcKKnowcK.controller.articleSummary;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -16,7 +14,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @AutoConfigureMockMvc
 @SpringBootTest
-@ExtendWith(SpringExtension.class)
 class LoadArticlesControllerTest {
 
     @Autowired
@@ -37,8 +34,6 @@ class LoadArticlesControllerTest {
 
         Long articleId = 2L;
         mockMvc.perform(MockMvcRequestBuilders.get("/api/article/{articleId}", articleId)).andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("id").value(articleId))
-                .andDo(print());
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON));
     }
 }

--- a/src/test/java/com/knu/KnowcKKnowcK/controller/articleSummary/LoadArticlesControllerTest.java
+++ b/src/test/java/com/knu/KnowcKKnowcK/controller/articleSummary/LoadArticlesControllerTest.java
@@ -1,0 +1,31 @@
+package com.knu.KnowcKKnowcK.controller.articleSummary;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@AutoConfigureMockMvc
+@SpringBootTest
+@ExtendWith(SpringExtension.class)
+class LoadArticlesControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @DisplayName("존재하는 모든 지문을 목록으로 조회한다.")
+    void loadArticles() throws Exception{
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/article/list")).andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON));
+
+    }
+}

--- a/src/test/java/com/knu/KnowcKKnowcK/controller/articleSummary/LoadArticlesControllerTest.java
+++ b/src/test/java/com/knu/KnowcKKnowcK/controller/articleSummary/LoadArticlesControllerTest.java
@@ -1,5 +1,6 @@
 package com.knu.KnowcKKnowcK.controller.articleSummary;
 
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -10,7 +11,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @AutoConfigureMockMvc
@@ -25,7 +26,19 @@ class LoadArticlesControllerTest {
     @DisplayName("존재하는 모든 지문을 목록으로 조회한다.")
     void loadArticles() throws Exception{
         mockMvc.perform(MockMvcRequestBuilders.get("/api/article/list")).andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON));
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andDo(print());
 
+    }
+
+    @Test
+    @DisplayName("id에 맞는 지문 1개를 조회한다.")
+    void loadArticleById() throws Exception{
+
+        Long articleId = 1L;
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/article/{articleId}", articleId)).andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("id").value(articleId))
+                .andDo(print());
     }
 }


### PR DESCRIPTION
## **PR**
## Feat: 문해력 진단 - 지문  조회


### ✨ 작업 내용

<지문 목록 조회>
-> 06fe7fccbf54bb73a6161d499d97b3a2bad01dfa

- `ArticleRepository` 추가
- `LoadArticlesService` 인터페이스, `LoadArticlesServiceImpl` 구현클래스 추가
- MockMvc 를 이용한 `LoadArticleController` 테스트 완료


<articleId로 지문 개별 조회>
-> 6fbe097187e876dc70d0ba83fe7d611441cc143e

- `id`로 지문 찾기 api 추가
- MockMvc 를 이용한 `loadArticleById` 테스트 완료
 - 로컬 디비 사용
---

### ✨ 참고 사항
- 각 기능 패키지 내에서 다시 도메인 별로 분리를 하고자 함 (도메인이 많아서..)
- swagger 를 사용해서 일단 rest api로 구현함 -> 추후 변경 원함
- `Article`의 모든 속성을 응답으로 보내면 될 것 같아서 따로 dto를 만들지 않음
---

### ⏰ 현재 버그

---

### ✏ Git Close
closed : #4 