### PR TITLE
Feat/issue #32

### DIFF
--- a/src/main/java/com/knu/KnowcKKnowcK/controller/AccountController.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/controller/AccountController.java
@@ -2,6 +2,7 @@ package com.knu.KnowcKKnowcK.controller;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;

--- a/src/main/java/com/knu/KnowcKKnowcK/controller/AccountController.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/controller/AccountController.java
@@ -14,6 +14,7 @@ import org.springframework.web.servlet.view.RedirectView;
 public class AccountController {
 
     @GetMapping( "/google")
+    @Operation(summary = "구글 로그인 및 회원가입 API", description = "구글 로그인 및 회원가입에 대한 API")
     public RedirectView redirectToGoogle() {
         RedirectView redirectView = new RedirectView();
         redirectView.setUrl("/oauth2/authorization/google");

--- a/src/main/java/com/knu/KnowcKKnowcK/domain/Member.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/domain/Member.java
@@ -22,11 +22,12 @@ public class Member {
     private Boolean isOAuth;
 
     @Builder
-    public Member(String name, String email, String profileImage, Boolean isOAuth) {
+    public Member(String name, String email, String profileImage, Boolean isOAuth, String password) {
         this.name = name;
         this.email = email;
         this.profileImage = profileImage;
         this.isOAuth = isOAuth;
+        this.password = password;
     }
 
     public Member update(String name, String profileImage) {

--- a/src/main/java/com/knu/KnowcKKnowcK/dto/oauth/OAuthAttributes.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/dto/oauth/OAuthAttributes.java
@@ -3,8 +3,9 @@ package com.knu.KnowcKKnowcK.dto.oauth;
 import com.knu.KnowcKKnowcK.domain.Member;
 import lombok.Builder;
 import lombok.Getter;
-
 import java.util.Map;
+
+import static com.knu.KnowcKKnowcK.service.account.AccountService.MemberPasswordGenerator.generateRandomPassword;
 
 @Getter
 public class OAuthAttributes {
@@ -43,6 +44,7 @@ public class OAuthAttributes {
                 .name(name)
                 .email(email)
                 .profileImage(profileImg)
+                .password(generateRandomPassword(10))
                 .isOAuth(true)
                 .build();
     }

--- a/src/main/java/com/knu/KnowcKKnowcK/exception/ErrorCode.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/exception/ErrorCode.java
@@ -15,7 +15,9 @@ public enum ErrorCode {
     FAILED(500,HttpStatus.BAD_REQUEST,"FAILED"),
     USER_NOT_FOUND(404,HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다"),
     INVALID_PERMISSION(401,HttpStatus.UNAUTHORIZED, "권한이 없습니다"),
-    INVALID_INPUT(400, HttpStatus.BAD_REQUEST,"잘못된 요청입니다.");
+    INVALID_INPUT(400, HttpStatus.BAD_REQUEST,"잘못된 요청입니다."),
+    ALREADY_REGISTERED(409, HttpStatus.CONFLICT,"이미 가입된 회원입니다");
+
     private int status;
     private HttpStatus error;
     private String message;

--- a/src/main/java/com/knu/KnowcKKnowcK/service/account/AccountService.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/service/account/AccountService.java
@@ -1,0 +1,37 @@
+package com.knu.KnowcKKnowcK.service.account;
+
+import com.knu.KnowcKKnowcK.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import java.security.SecureRandom;
+
+@Service
+@RequiredArgsConstructor
+public class AccountService {
+
+    private final MemberRepository memberRepository;
+
+
+    public class MemberPasswordGenerator {
+
+        private static final String CHAR_LOWER = "abcdefghijklmnopqrstuvwxyz";
+        private static final String CHAR_UPPER = CHAR_LOWER.toUpperCase();
+        private static final String NUMBER = "0123456789";
+        private static final String SPECIAL_CHARS = "!@#$%^&*()_-+=<>?";
+
+        private static final String PASSWORD_CHARS = CHAR_LOWER + CHAR_UPPER + NUMBER + SPECIAL_CHARS;
+
+        public static String generateRandomPassword(int length) {
+            SecureRandom random = new SecureRandom();
+            StringBuilder password = new StringBuilder();
+
+            for (int i = 0; i < length; i++) {
+                int index = random.nextInt(PASSWORD_CHARS.length());
+                password.append(PASSWORD_CHARS.charAt(index));
+            }
+
+            return password.toString();
+        }
+
+    }
+}


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용
- 중복 회원가입 시도에 대한 처리
- 소셜 회원가입 멤버에 대한 랜덤 비밀번호 생성
---

### ✨ 참고 사항
- security에서 login success/failure handler 추가 계획
---

### ⏰ 현재 버그

---

### 🤔 궁금한점
- 성공에 대한 응답이 아닌 경우에, 응답으로 data를 담아서 보낼 일이 있으면 `ApiResponseDto.error` 를 사용해서 보내고   
에러 상황만 알리는 것이라면 `CustomException` 을 쓴다고 이해를 하면 되는걸까요...??   
아니면 흐름 중단에 대한 관점으로 생각을 해야할까요?

---

### ✏ Git Close 
#32 