### PR TITLE
Feat/issue #34 (요약 수동 저장 시 AI 피드백 제공)

### DIFF
--- a/src/main/java/com/knu/KnowcKKnowcK/controller/DebateRoomController.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/controller/DebateRoomController.java
@@ -23,7 +23,7 @@ public class DebateRoomController {
     private final MemberRepository memberRepository;
     private Member member; // 로그인 기능 추가되면 수정 예정
 
-    @PostMapping("/{debateRoomId}")
+    @PutMapping("/{debateRoomId}")
     @Operation(summary = "토론방 참여 API", description = "클라이언트가 토론방에 참여하길 바랄 때 요청하는 API")
     @Parameters({@Parameter(name = "debateRoomId", description = "참여하길 바라는 토론방 ID", example = "3")})
     @ApiResponses({

--- a/src/main/java/com/knu/KnowcKKnowcK/controller/MessageController.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/controller/MessageController.java
@@ -6,6 +6,7 @@ import com.knu.KnowcKKnowcK.domain.Member;
 import com.knu.KnowcKKnowcK.dto.requestdto.PreferenceRequestDto;
 import com.knu.KnowcKKnowcK.dto.responsedto.MessageResponseDto;
 import com.knu.KnowcKKnowcK.dto.responsedto.MessageThreadResponseDto;
+import com.knu.KnowcKKnowcK.dto.responsedto.PreferenceResponseDto;
 import com.knu.KnowcKKnowcK.repository.MemberRepository;
 import com.knu.KnowcKKnowcK.service.debateRoom.MessageService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -63,7 +64,7 @@ public class MessageController {
             @ApiResponse(responseCode = "200", description = "동의 추가 성공"),
             @ApiResponse(responseCode = "400", description = "동의 추가 실패")
     })
-    public ApiResponseDto<Double> putPreference(@PathVariable Long messageId, @RequestBody PreferenceRequestDto preferenceRequestDTO) {
+    public ApiResponseDto<PreferenceResponseDto> putPreference(@PathVariable Long messageId, @RequestBody PreferenceRequestDto preferenceRequestDTO) {
         member = memberRepository.findById(1L).orElse(null);
         return ApiResponseDto.success(SuccessCode.OK, messageService.putPreference(member, messageId, preferenceRequestDTO));
     }

--- a/src/main/java/com/knu/KnowcKKnowcK/domain/Message.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/domain/Message.java
@@ -34,14 +34,17 @@ public class Message {
     private String content;
     private LocalDateTime createdTime;
 
-    public MessageResponseDto toMessageResponseDto(String position){
+    public MessageResponseDto toMessageResponseDto(String position, long likesNum, long threadNum, String profileImage){
         return MessageResponseDto.builder()
                 .writer(member.getName())
+                .likesNum(likesNum)
+                .profileImage(profileImage)
                 .content(content)
                 .createdTime(createdTime)
                 .roomId(debateRoom.getId())
                 .messageId(id)
                 .position(position)
+                .threadNum(threadNum)
                 .build();
     }
 }

--- a/src/main/java/com/knu/KnowcKKnowcK/domain/MessageThread.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/domain/MessageThread.java
@@ -34,6 +34,7 @@ public class MessageThread {
 
     public MessageThreadResponseDto toMessageThreadResponseDto(Long parentMessageId){
         return MessageThreadResponseDto.builder()
+                .threadId(id)
                 .content(content)
                 .createdTime(createdTime)
                 .parentMessageId(parentMessageId)

--- a/src/main/java/com/knu/KnowcKKnowcK/domain/SummaryFeedback.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/domain/SummaryFeedback.java
@@ -5,6 +5,8 @@ import lombok.*;
 
 @Entity
 @Getter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SummaryFeedback {
 

--- a/src/main/java/com/knu/KnowcKKnowcK/dto/prompt/SummaryPrompt.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/dto/prompt/SummaryPrompt.java
@@ -3,7 +3,7 @@ package com.knu.KnowcKKnowcK.dto.prompt;
 public class SummaryPrompt {
     private String prompt;
     private SummaryPrompt(){
-        prompt = "아래 기사 내용을 요약한 것에 대한 평가를 해줘 \n\n";
+        prompt = "신문기사 내용과 이에 대한 요약에 대해 문해력 피드백과 100점 기준의 점수를 주는 것이 당신의 역할입니다. 신문 기사 내용와 요약은 줄바꿈으로 구분합니다. 피드백의 양식은 \"score(only integer)#feedback(String)\" 입니다. 아래에 신문 기사 내용과 요약을 작성할테니 이에 대한 피드백을 양식을 꼭 지켜서 만들어주세요. 피드백만 작성하세요. \n\n";
     }
     private static class HOLDER{
         public static final SummaryPrompt INSTANCE = new SummaryPrompt();

--- a/src/main/java/com/knu/KnowcKKnowcK/dto/responsedto/MessageResponseDto.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/dto/responsedto/MessageResponseDto.java
@@ -11,8 +11,12 @@ import java.time.LocalDateTime;
 public class MessageResponseDto {
     Long roomId;
     Long messageId;
+    String profileImage;
     String writer;
     String position;
     String content;
+
+    Long likesNum;
+    Long threadNum;
     LocalDateTime createdTime;
 }

--- a/src/main/java/com/knu/KnowcKKnowcK/dto/responsedto/MessageThreadResponseDto.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/dto/responsedto/MessageThreadResponseDto.java
@@ -10,6 +10,7 @@ import java.time.LocalDateTime;
 @Builder
 @AllArgsConstructor
 public class MessageThreadResponseDto {
+    Long threadId;
     Long parentMessageId;
     String writer;
     String content;

--- a/src/main/java/com/knu/KnowcKKnowcK/dto/responsedto/PreferenceResponseDto.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/dto/responsedto/PreferenceResponseDto.java
@@ -1,0 +1,11 @@
+package com.knu.KnowcKKnowcK.dto.responsedto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class PreferenceResponseDto {
+    private Double ratio;
+    private Boolean isIncrease;
+}

--- a/src/main/java/com/knu/KnowcKKnowcK/repository/PreferenceRepository.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/repository/PreferenceRepository.java
@@ -5,8 +5,10 @@ import com.knu.KnowcKKnowcK.domain.Message;
 import com.knu.KnowcKKnowcK.domain.Preference;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface PreferenceRepository extends JpaRepository<Preference, Long> {
     Optional<Preference> findByMemberAndMessage(Member member, Message message);
+    List<Preference> findByMessage(Message message);
 }

--- a/src/main/java/com/knu/KnowcKKnowcK/repository/SummaryFeedbackRepository.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/repository/SummaryFeedbackRepository.java
@@ -1,0 +1,9 @@
+package com.knu.KnowcKKnowcK.repository;
+
+import com.knu.KnowcKKnowcK.domain.SummaryFeedback;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SummaryFeedbackRepository extends JpaRepository<SummaryFeedback, Long> {
+}

--- a/src/main/java/com/knu/KnowcKKnowcK/repository/SummaryRepository.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/repository/SummaryRepository.java
@@ -1,7 +1,13 @@
 package com.knu.KnowcKKnowcK.repository;
 
+import com.knu.KnowcKKnowcK.domain.Article;
+import com.knu.KnowcKKnowcK.domain.Member;
 import com.knu.KnowcKKnowcK.domain.Summary;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface SummaryRepository extends JpaRepository<Summary, Long> {
+
+    Optional<Summary> findByArticleAndWriter(Article article, Member writer);
 }

--- a/src/main/java/com/knu/KnowcKKnowcK/service/articleSummary/SaveSummaryServiceImpl.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/service/articleSummary/SaveSummaryServiceImpl.java
@@ -3,6 +3,7 @@ package com.knu.KnowcKKnowcK.service.articleSummary;
 import com.knu.KnowcKKnowcK.domain.Article;
 import com.knu.KnowcKKnowcK.domain.Member;
 import com.knu.KnowcKKnowcK.domain.Summary;
+import com.knu.KnowcKKnowcK.domain.SummaryFeedback;
 import com.knu.KnowcKKnowcK.dto.requestdto.SummaryRequestDto;
 import com.knu.KnowcKKnowcK.dto.responsedto.SummaryResponseDto;
 import com.knu.KnowcKKnowcK.enums.Status;
@@ -10,9 +11,14 @@ import com.knu.KnowcKKnowcK.exception.CustomException;
 import com.knu.KnowcKKnowcK.exception.ErrorCode;
 import com.knu.KnowcKKnowcK.repository.ArticleRepository;
 import com.knu.KnowcKKnowcK.repository.MemberRepository;
+import com.knu.KnowcKKnowcK.repository.SummaryFeedbackRepository;
 import com.knu.KnowcKKnowcK.repository.SummaryRepository;
+import com.knu.KnowcKKnowcK.service.chatGptService.SummaryFeedbackService;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.Optional;
 
 
 @Service
@@ -21,23 +27,51 @@ public class SaveSummaryServiceImpl implements SaveSummaryService{
 
 
     private final SummaryRepository summaryRepository;
+
+    private final SummaryFeedbackRepository summaryFeedbackRepository;
+
     private final ArticleRepository articleRepository;
+
     private final MemberRepository memberRepository;
 
+    private final SummaryFeedbackService summaryFeedbackService;
+
     @Override
+    @Transactional
     public SummaryResponseDto saveSummary(SummaryRequestDto dto) {
         Article article = articleRepository.findById(dto.getArticleId()).orElseThrow(()-> new CustomException(ErrorCode.INVALID_INPUT));
         Member member = memberRepository.findById(dto.getWriterId()).orElseThrow(() -> new CustomException(ErrorCode.INVALID_INPUT));
+        Optional<Summary> existedSummary = summaryRepository.findByArticleAndWriter(article, member);
 
-        Summary summary = dto.toEntity(article, member);
-        Summary savedSummary = summaryRepository.save(summary);
+        if (existedSummary.isPresent() && existedSummary.get().getStatus().equals(Status.ING) && existedSummary.get().getTakenTime() > dto.getTakenTime()) {
+                throw new CustomException(ErrorCode.INVALID_INPUT);
+        }
+
+        Summary savedSummary = summaryRepository.save(dto.toEntity(article, member));
 
         if (savedSummary.getStatus().equals(Status.ING)){
             return new SummaryResponseDto("임시 저장이 완료되었습니다.");
 
-        }
+        } else if (savedSummary.getStatus().equals(Status.DONE)) {
+            String content = summaryFeedbackService.callGptApi(article.getContent(), savedSummary.getContent());
+            SummaryFeedback savedFeedback = summaryFeedbackRepository.save(parsingFeedbackToEntity(content, savedSummary));
+            return new SummaryResponseDto(savedFeedback);
 
-        // Status.DONE 인 경우 피드백 요청 시작
-        throw new CustomException(ErrorCode.FAILED);
+        } else {
+            throw new CustomException(ErrorCode.FAILED);
+
+        }
+    }
+
+    private SummaryFeedback parsingFeedbackToEntity(String content, Summary savedSummary){
+        String[] split = content.split("#");
+        int score = Integer.parseInt(split[0]);
+        String feedback = split[1];
+
+        return SummaryFeedback.builder()
+                .summary(savedSummary)
+                .content(feedback)
+                .score(score)
+                .build();
     }
 }

--- a/src/main/java/com/knu/KnowcKKnowcK/service/debateRoom/MessageService.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/service/debateRoom/MessageService.java
@@ -27,6 +27,7 @@ public class MessageService {
     private final MessageThreadRepository messageThreadRepository;
     private final PreferenceRepository preferenceRepository;
     private final MemberDebateRepository memberDebateRepository;
+
     public MessageResponseDto saveAndReturnMessage(Member member, MessageRequestDto messageRequestDto){
         DebateRoom debateRoom = debateRoomRepository.findById(messageRequestDto.getRoomId())
                 .orElseThrow(() -> new CustomException(ErrorCode.INVALID_INPUT));
@@ -36,7 +37,9 @@ public class MessageService {
         Message message = messageRequestDto.toMessage(member, debateRoom);
         messageRepository.save(message);
 
-        return message.toMessageResponseDto(memberDebate.getPosition().name());
+        return message.toMessageResponseDto(memberDebate.getPosition().name(),
+                0, 0,
+                member.getProfileImage());
     }
     public MessageThreadResponseDto saveAndReturnMessageThread(Member member, Long messageId, MessageThreadRequestDto messageThreadRequestDto) {
         Message message = messageRepository.findById(messageId)
@@ -56,7 +59,12 @@ public class MessageService {
 
         List<MessageResponseDto> messageResponseDtoList = new ArrayList<>();
         for (Message message: messageList) {
-            messageResponseDtoList.add(message.toMessageResponseDto(memberDebate.getPosition().name()));
+            messageResponseDtoList.add(message
+                    .toMessageResponseDto(memberDebate.getPosition().name(),
+                            getPreferenceNum(message),
+                            getMessageThreadNum(message) ,
+                            message.getMember().getProfileImage()
+                            ));
         }
         return messageResponseDtoList;
     }
@@ -123,4 +131,13 @@ public class MessageService {
         debateRoomRepository.save(debateRoom);
         return debateRoom;
     }
+
+    private long getPreferenceNum(Message message){
+        return preferenceRepository.findByMessage(message).size();
+    }
+
+    private long getMessageThreadNum(Message message){
+        return messageThreadRepository.findByMessage(message).size();
+    }
+
 }

--- a/src/main/java/com/knu/KnowcKKnowcK/service/debateRoom/MessageService.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/service/debateRoom/MessageService.java
@@ -7,6 +7,7 @@ import com.knu.KnowcKKnowcK.dto.requestdto.MessageThreadRequestDto;
 import com.knu.KnowcKKnowcK.dto.requestdto.PreferenceRequestDto;
 import com.knu.KnowcKKnowcK.dto.responsedto.MessageResponseDto;
 import com.knu.KnowcKKnowcK.dto.responsedto.MessageThreadResponseDto;
+import com.knu.KnowcKKnowcK.dto.responsedto.PreferenceResponseDto;
 import com.knu.KnowcKKnowcK.exception.CustomException;
 import com.knu.KnowcKKnowcK.exception.ErrorCode;
 import com.knu.KnowcKKnowcK.repository.*;
@@ -81,7 +82,7 @@ public class MessageService {
         return messageThreadResponseDtoList;
     }
 
-    public Double putPreference(Member member, Long messageId, PreferenceRequestDto preferenceRequestDto){
+    public PreferenceResponseDto putPreference(Member member, Long messageId, PreferenceRequestDto preferenceRequestDto){
         preferenceRequestDto.validate();
         Message message = messageRepository.findById(messageId)
                 .orElseThrow(() -> new CustomException(ErrorCode.INVALID_INPUT));
@@ -96,7 +97,10 @@ public class MessageService {
                 isIncrease,
                 message.getDebateRoom());
 
-        return calculateRatio(debateRoom.getAgreeLikesNum(), debateRoom.getDisagreeLikesNum());
+        return makeDto(
+                calculateRatio(debateRoom.getAgreeLikesNum(), debateRoom.getDisagreeLikesNum()),
+                isIncrease
+        );
     }
 
     private boolean updatePreference(Member member, Message message, PreferenceRequestDto preferenceRequestDto){
@@ -140,4 +144,10 @@ public class MessageService {
         return messageThreadRepository.findByMessage(message).size();
     }
 
+    private PreferenceResponseDto makeDto(double ratio, boolean isIncrease){
+        return PreferenceResponseDto.builder()
+                .ratio(ratio)
+                .isIncrease(isIncrease)
+                .build();
+    }
 }


### PR DESCRIPTION
## **PR**
Feat: 요약 수동 저장 시 AI 피드백 제공

### ✨ 작업 내용
- `@Transactional` 추가로 저장 덮어쓰기까지 가능하도록
- 그런데 이렇게 하려면 `Summary` PK를 article과 member 두가지 복합키로 정의해야하지 않을까 생각함
- 저장돼있는 요약 소요 시간보다 업데이트할 요약 소요시간이 적을 경우 예외처리
- `parsingFeedbackToEntity` 메서드로 피드백 파싱
- 피드백은 **"score#content"** 양식으로 맞춰서 파싱하기 쉽도록 하면 좋을 것 같음
- 단위 테스트 완료 (이전까지 했던건 `@SpringBootTest` 를 이용한 통합 테스트였음 .. ㅠ)
---

### ✨ 참고 사항
- ChatGPT 부분 api 테스트가 필요함
---

### ⏰ 현재 버그
X
---

### ✏ Git Close