### PR TITLE
Feat/issue #33 PR 리뷰 반영 (AI 피드백 파싱 메서드 위치 변경, Summary 엔티티에 Persistable 추가)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'io.netty:netty-resolver-dns-native-macos:4.1.68.Final:osx-aarch_64'
 
 	//database
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/src/main/java/com/knu/KnowcKKnowcK/domain/Summary.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/domain/Summary.java
@@ -3,6 +3,7 @@ package com.knu.KnowcKKnowcK.domain;
 import com.knu.KnowcKKnowcK.enums.Status;
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.data.domain.Persistable;
 
 import java.time.LocalDateTime;
 
@@ -11,7 +12,7 @@ import java.time.LocalDateTime;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Summary {
+public class Summary implements Persistable<Long> {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -35,5 +36,12 @@ public class Summary {
     private Status status;
 
     private Long takenTime;
+
+
+    @Override
+    public boolean isNew() {
+        return writer == null && article == null;
+
+    }
 
 }

--- a/src/main/java/com/knu/KnowcKKnowcK/domain/Summary.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/domain/Summary.java
@@ -3,7 +3,6 @@ package com.knu.KnowcKKnowcK.domain;
 import com.knu.KnowcKKnowcK.enums.Status;
 import jakarta.persistence.*;
 import lombok.*;
-import org.springframework.data.domain.Persistable;
 
 import java.time.LocalDateTime;
 
@@ -12,7 +11,7 @@ import java.time.LocalDateTime;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Summary implements Persistable<Long> {
+public class Summary {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -37,11 +36,11 @@ public class Summary implements Persistable<Long> {
 
     private Long takenTime;
 
+    public Summary update(String content, Status status, Long takenTime) {
+        this.content = content;
+        this.status = status;
+        this.takenTime = takenTime;
 
-    @Override
-    public boolean isNew() {
-        return writer == null && article == null;
-
+        return this;
     }
-
 }

--- a/src/main/java/com/knu/KnowcKKnowcK/domain/SummaryFeedback.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/domain/SummaryFeedback.java
@@ -5,6 +5,8 @@ import lombok.*;
 
 @Entity
 @Getter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SummaryFeedback {
 

--- a/src/main/java/com/knu/KnowcKKnowcK/dto/prompt/SummaryPrompt.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/dto/prompt/SummaryPrompt.java
@@ -3,7 +3,7 @@ package com.knu.KnowcKKnowcK.dto.prompt;
 public class SummaryPrompt {
     private String prompt;
     private SummaryPrompt(){
-        prompt = "신문기사 내용과 이에 대한 요약에 대해 문해력 피드백과 100점 기준의 점수를 주는 것이 당신의 역할입니다. 신문 기사 내용와 요약은 줄바꿈으로 구분합니다. 피드백의 양식은 \"score(only integer)#feedback(String)\" 입니다. 아래에 신문 기사 내용과 요약을 작성할테니 이에 대한 피드백을 양식을 꼭 지켜서 만들어주세요. 피드백만 작성하세요. \n\n";
+        prompt = "신문기사 내용과 이에 대한 요약에 대해 문해력 피드백과 100점 기준의 점수를 주는 것이 당신의 역할입니다. 신문 기사 내용와 요약은 줄바꿈으로 구분합니다. 피드백의 양식은 반드시 \"숫자#문자열\" 와 같아야합니다. 피드백 양식 예시는 \"90#요약에 대한 평가\"입니다. 아래에 신문 기사 내용과 요약을 작성할테니 이에 대한 피드백을 양식을 꼭 지켜서 만들어주세요. 피드백만 작성하세요. \n\n";
     }
     private static class HOLDER{
         public static final SummaryPrompt INSTANCE = new SummaryPrompt();

--- a/src/main/java/com/knu/KnowcKKnowcK/dto/prompt/SummaryPrompt.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/dto/prompt/SummaryPrompt.java
@@ -3,7 +3,7 @@ package com.knu.KnowcKKnowcK.dto.prompt;
 public class SummaryPrompt {
     private String prompt;
     private SummaryPrompt(){
-        prompt = "아래 기사 내용을 요약한 것에 대한 평가를 해줘 \n\n";
+        prompt = "신문기사 내용과 이에 대한 요약에 대해 문해력 피드백과 100점 기준의 점수를 주는 것이 당신의 역할입니다. 신문 기사 내용와 요약은 줄바꿈으로 구분합니다. 피드백의 양식은 \"score(only integer)#feedback(String)\" 입니다. 아래에 신문 기사 내용과 요약을 작성할테니 이에 대한 피드백을 양식을 꼭 지켜서 만들어주세요. 피드백만 작성하세요. \n\n";
     }
     private static class HOLDER{
         public static final SummaryPrompt INSTANCE = new SummaryPrompt();

--- a/src/main/java/com/knu/KnowcKKnowcK/repository/SummaryFeedbackRepository.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/repository/SummaryFeedbackRepository.java
@@ -1,0 +1,9 @@
+package com.knu.KnowcKKnowcK.repository;
+
+import com.knu.KnowcKKnowcK.domain.SummaryFeedback;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SummaryFeedbackRepository extends JpaRepository<SummaryFeedback, Long> {
+}

--- a/src/main/java/com/knu/KnowcKKnowcK/repository/SummaryRepository.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/repository/SummaryRepository.java
@@ -1,7 +1,13 @@
 package com.knu.KnowcKKnowcK.repository;
 
+import com.knu.KnowcKKnowcK.domain.Article;
+import com.knu.KnowcKKnowcK.domain.Member;
 import com.knu.KnowcKKnowcK.domain.Summary;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface SummaryRepository extends JpaRepository<Summary, Long> {
+
+    Optional<Summary> findByArticleAndWriter(Article article, Member writer);
 }

--- a/src/main/java/com/knu/KnowcKKnowcK/service/articleSummary/SaveSummaryServiceImpl.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/service/articleSummary/SaveSummaryServiceImpl.java
@@ -43,12 +43,16 @@ public class SaveSummaryServiceImpl implements SaveSummaryService{
         Article article = articleRepository.findById(dto.getArticleId()).orElseThrow(()-> new CustomException(ErrorCode.INVALID_INPUT));
         Member member = memberRepository.findById(dto.getWriterId()).orElseThrow(() -> new CustomException(ErrorCode.INVALID_INPUT));
         Optional<Summary> existedSummary = summaryRepository.findByArticleAndWriter(article, member);
+        Summary savedSummary;
 
-        if (existedSummary.isPresent() && existedSummary.get().getStatus().equals(Status.ING) && existedSummary.get().getTakenTime() > dto.getTakenTime()) {
+        if (existedSummary.isPresent()){
+            if(existedSummary.get().getStatus().equals(Status.ING) && existedSummary.get().getTakenTime() > dto.getTakenTime()){
                 throw new CustomException(ErrorCode.INVALID_INPUT);
+            }
+            savedSummary = existedSummary.get().update(dto.getContent(), dto.getStatus(), dto.getTakenTime());
+        } else {
+            savedSummary = summaryRepository.save(dto.toEntity(article, member));
         }
-
-        Summary savedSummary = summaryRepository.save(dto.toEntity(article, member));
 
         if (savedSummary.getStatus().equals(Status.ING)){
             return new SummaryResponseDto("임시 저장이 완료되었습니다.");

--- a/src/main/java/com/knu/KnowcKKnowcK/service/articleSummary/SaveSummaryServiceImpl.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/service/articleSummary/SaveSummaryServiceImpl.java
@@ -3,6 +3,7 @@ package com.knu.KnowcKKnowcK.service.articleSummary;
 import com.knu.KnowcKKnowcK.domain.Article;
 import com.knu.KnowcKKnowcK.domain.Member;
 import com.knu.KnowcKKnowcK.domain.Summary;
+import com.knu.KnowcKKnowcK.domain.SummaryFeedback;
 import com.knu.KnowcKKnowcK.dto.requestdto.SummaryRequestDto;
 import com.knu.KnowcKKnowcK.dto.responsedto.SummaryResponseDto;
 import com.knu.KnowcKKnowcK.enums.Status;
@@ -10,9 +11,14 @@ import com.knu.KnowcKKnowcK.exception.CustomException;
 import com.knu.KnowcKKnowcK.exception.ErrorCode;
 import com.knu.KnowcKKnowcK.repository.ArticleRepository;
 import com.knu.KnowcKKnowcK.repository.MemberRepository;
+import com.knu.KnowcKKnowcK.repository.SummaryFeedbackRepository;
 import com.knu.KnowcKKnowcK.repository.SummaryRepository;
+import com.knu.KnowcKKnowcK.service.chatGptService.SummaryFeedbackService;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.Optional;
 
 
 @Service
@@ -21,23 +27,51 @@ public class SaveSummaryServiceImpl implements SaveSummaryService{
 
 
     private final SummaryRepository summaryRepository;
+
+    private final SummaryFeedbackRepository summaryFeedbackRepository;
+
     private final ArticleRepository articleRepository;
+
     private final MemberRepository memberRepository;
 
+    private final SummaryFeedbackService summaryFeedbackService;
+
     @Override
+    @Transactional
     public SummaryResponseDto saveSummary(SummaryRequestDto dto) {
         Article article = articleRepository.findById(dto.getArticleId()).orElseThrow(()-> new CustomException(ErrorCode.INVALID_INPUT));
         Member member = memberRepository.findById(dto.getWriterId()).orElseThrow(() -> new CustomException(ErrorCode.INVALID_INPUT));
+        Optional<Summary> existedSummary = summaryRepository.findByArticleAndWriter(article, member);
 
-        Summary summary = dto.toEntity(article, member);
-        Summary savedSummary = summaryRepository.save(summary);
+        if (existedSummary.isPresent() && existedSummary.get().getStatus().equals(Status.ING) && existedSummary.get().getTakenTime() > dto.getTakenTime()) {
+                throw new CustomException(ErrorCode.INVALID_INPUT);
+        }
+
+        Summary savedSummary = summaryRepository.save(dto.toEntity(article, member));
 
         if (savedSummary.getStatus().equals(Status.ING)){
             return new SummaryResponseDto("임시 저장이 완료되었습니다.");
 
-        }
+        } else if (savedSummary.getStatus().equals(Status.DONE)) {
+            String content = summaryFeedbackService.callGptApi(article.getContent(), savedSummary.getContent());
+            SummaryFeedback savedFeedback = summaryFeedbackRepository.save(parsingFeedbackToEntity(content, savedSummary));
+            return new SummaryResponseDto(savedFeedback);
 
-        // Status.DONE 인 경우 피드백 요청 시작
-        throw new CustomException(ErrorCode.FAILED);
+        } else {
+            throw new CustomException(ErrorCode.FAILED);
+
+        }
+    }
+
+    private SummaryFeedback parsingFeedbackToEntity(String content, Summary savedSummary){
+        String[] split = content.split("#");
+        int score = Integer.parseInt(split[0]);
+        String feedback = split[1];
+
+        return SummaryFeedback.builder()
+                .summary(savedSummary)
+                .content(feedback)
+                .score(score)
+                .build();
     }
 }

--- a/src/main/java/com/knu/KnowcKKnowcK/service/chatGptService/ChatGptContext.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/service/chatGptService/ChatGptContext.java
@@ -2,7 +2,9 @@ package com.knu.KnowcKKnowcK.service.chatGptService;
 
 import com.knu.KnowcKKnowcK.enums.Option;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.util.Pair;
 import org.springframework.stereotype.Component;
+
 
 @Component
 @RequiredArgsConstructor
@@ -11,7 +13,7 @@ public class ChatGptContext {
     private final OpinionFeedbackService opinionFeedbackService;
 
 
-    public String callGptApi(Option op, String article, String answer){
+    public Pair<Integer, String> callGptApi(Option op, String article, String answer){
         if(op==Option.SUMMARY)
             return this.summaryFeedbackService.callGptApi(article, answer);
         else

--- a/src/main/java/com/knu/KnowcKKnowcK/service/chatGptService/ChatGptService.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/service/chatGptService/ChatGptService.java
@@ -1,6 +1,8 @@
 package com.knu.KnowcKKnowcK.service.chatGptService;
 
 
+import org.springframework.data.util.Pair;
+
 public interface ChatGptService {
-    String callGptApi(String article, String summary);
+    Pair<Integer, String> callGptApi(String article, String summary);
 }

--- a/src/main/java/com/knu/KnowcKKnowcK/service/chatGptService/ChatGptServiceTest.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/service/chatGptService/ChatGptServiceTest.java
@@ -2,6 +2,7 @@ package com.knu.KnowcKKnowcK.service.chatGptService;
 
 import com.knu.KnowcKKnowcK.enums.Option;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.util.Pair;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -9,7 +10,7 @@ import org.springframework.stereotype.Service;
 public class ChatGptServiceTest {
     private final ChatGptContext chatGptContext;
 
-    public String test(){
+    public Pair<Integer, String> test(){
         // Option.OPINION or Option.SUMMARY 로 요약인지 견해인지를 구분
         return chatGptContext.callGptApi(Option.OPINION,"오늘의 날씨","오늘 날씨");
     }

--- a/src/main/java/com/knu/KnowcKKnowcK/service/chatGptService/OpinionFeedbackService.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/service/chatGptService/OpinionFeedbackService.java
@@ -5,6 +5,7 @@ import com.knu.KnowcKKnowcK.dto.prompt.OpinionPrompt;
 import com.knu.KnowcKKnowcK.dto.requestdto.ChatgptRequestDto;
 import com.knu.KnowcKKnowcK.dto.responsedto.ChatgptResponseDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.util.Pair;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.BodyInserters;
 
@@ -17,11 +18,10 @@ public class OpinionFeedbackService  implements ChatGptService{
 
     private final ChatGptConfig chatGptConfig;
     @Override
-    public String callGptApi(String article, String summary) {
+    public Pair<Integer, String> callGptApi(String article, String summary) {
         List<ChatgptRequestDto.Message> messageList = new ArrayList<>();
         messageList.add(new ChatgptRequestDto.Message("user", OpinionPrompt.getInstance().getPrompt() + article + summary));
         ChatgptRequestDto requestDto = new ChatgptRequestDto(messageList);
-
 
         ChatgptResponseDto responseDto = chatGptConfig.gptClient()
                 .post()
@@ -29,9 +29,16 @@ public class OpinionFeedbackService  implements ChatGptService{
                 .retrieve()
                 .bodyToMono(ChatgptResponseDto.class)
                 .block();
-        String result = responseDto.getChoices().get(0).getMessage().getContent();
 
+        return parsingFeedback(responseDto.getChoices().get(0).getMessage().getContent());
+    }
 
-        return result;
+    private Pair<Integer, String> parsingFeedback(String content){
+
+        String[] split = content.split("#");
+        int score = Integer.parseInt(split[0]);
+        String feedback = split[1];
+
+        return Pair.of(score, feedback);
     }
 }

--- a/src/main/java/com/knu/KnowcKKnowcK/service/chatGptService/SummaryFeedbackService.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/service/chatGptService/SummaryFeedbackService.java
@@ -4,7 +4,10 @@ import com.knu.KnowcKKnowcK.config.ChatGptConfig;
 import com.knu.KnowcKKnowcK.dto.prompt.SummaryPrompt;
 import com.knu.KnowcKKnowcK.dto.requestdto.ChatgptRequestDto;
 import com.knu.KnowcKKnowcK.dto.responsedto.ChatgptResponseDto;
+import com.knu.KnowcKKnowcK.exception.CustomException;
+import com.knu.KnowcKKnowcK.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.util.Pair;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.BodyInserters;
 
@@ -16,12 +19,11 @@ import java.util.List;
 public class SummaryFeedbackService implements ChatGptService{
     private final ChatGptConfig chatGptConfig;
     @Override
-    public String callGptApi(String article, String summary) {
+    public Pair<Integer, String> callGptApi(String article, String summary) {
 
         List<ChatgptRequestDto.Message> messageList = new ArrayList<>();
         messageList.add(new ChatgptRequestDto.Message("user", SummaryPrompt.getInstance().getPrompt() + article + summary));
         ChatgptRequestDto requestDto = new ChatgptRequestDto(messageList);
-
 
         ChatgptResponseDto responseDto = chatGptConfig.gptClient()
                 .post()
@@ -29,9 +31,22 @@ public class SummaryFeedbackService implements ChatGptService{
                 .retrieve()
                 .bodyToMono(ChatgptResponseDto.class)
                 .block();
-        String result = responseDto.getChoices().get(0).getMessage().getContent();
 
+        return parsingFeedback(responseDto.getChoices().get(0).getMessage().getContent());
+    }
 
-        return result;
+    private Pair<Integer, String> parsingFeedback(String content){
+
+        try {
+            String[] split = content.split("#");
+            int score = Integer.parseInt(split[0]);
+            String feedback = split[1];
+
+            return Pair.of(score, feedback);
+
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.INVALID_INPUT);
+        }
+
     }
 }

--- a/src/main/java/com/knu/KnowcKKnowcK/service/chatGptService/SummaryFeedbackService.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/service/chatGptService/SummaryFeedbackService.java
@@ -4,8 +4,6 @@ import com.knu.KnowcKKnowcK.config.ChatGptConfig;
 import com.knu.KnowcKKnowcK.dto.prompt.SummaryPrompt;
 import com.knu.KnowcKKnowcK.dto.requestdto.ChatgptRequestDto;
 import com.knu.KnowcKKnowcK.dto.responsedto.ChatgptResponseDto;
-import com.knu.KnowcKKnowcK.exception.CustomException;
-import com.knu.KnowcKKnowcK.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.util.Pair;
 import org.springframework.stereotype.Service;
@@ -36,17 +34,12 @@ public class SummaryFeedbackService implements ChatGptService{
     }
 
     private Pair<Integer, String> parsingFeedback(String content){
+            System.out.println("score = " + content);
 
-        try {
             String[] split = content.split("#");
             int score = Integer.parseInt(split[0]);
             String feedback = split[1];
 
             return Pair.of(score, feedback);
-
-        } catch (Exception e) {
-            throw new CustomException(ErrorCode.INVALID_INPUT);
-        }
-
     }
 }

--- a/src/test/java/com/knu/KnowcKKnowcK/controller/articleSummary/SaveSummaryControllerTest.java
+++ b/src/test/java/com/knu/KnowcKKnowcK/controller/articleSummary/SaveSummaryControllerTest.java
@@ -1,44 +1,42 @@
-//package com.knu.KnowcKKnowcK.controller.articleSummary;
-//
-//import org.junit.jupiter.api.Test;
-//import org.springframework.beans.factory.annotation.Autowired;
-//import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-//import org.springframework.boot.test.context.SpringBootTest;
-//import org.springframework.context.annotation.Configuration;
-//import org.springframework.http.MediaType;
-//import org.springframework.test.web.servlet.MockMvc;
-//import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-//import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
-//
-//import static org.junit.jupiter.api.Assertions.*;
-//import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-//
-//@SpringBootTest
-//@AutoConfigureMockMvc
-//class SaveSummaryControllerTest {
-//
-//
-//    @Autowired
-//    private MockMvc mockMvc;
-//
-//    @Test
-//    void saveSummary() throws Exception{
-//
-//        String request = "{\n" +
-//                "  \"articleId\": 1,\n" +
-//                "  \"writerId\": 2,\n" +
-//                "  \"content\": \"이 문서는 더미 데이터입니다.\",\n" +
-//                "  \"createdTime\": \"2023-05-15T10:30:00\",\n" +
-//                "  \"status\": \"PUBLISHED\",\n" +
-//                "  \"takenTime\": 30\n" +
-//                "}\n";
-//
-//        mockMvc.perform(
-//                MockMvcRequestBuilders.post("/api/summary/save")
-//                        .contentType(MediaType.APPLICATION_JSON)
-//                        .content(request))
-//                .andExpect(MockMvcResultMatchers.status().isOk())
-//                .andDo(print());
-//
-//    }
-//}
+package com.knu.KnowcKKnowcK.controller.articleSummary;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class SaveSummaryControllerTest {
+
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void saveSummary() throws Exception{
+
+        String request = "{\n" +
+                "  \"articleId\": \"1\",\n" +
+                "  \"writerId\": \"2\",\n" +
+                "  \"content\": \"이 문서는 더미 데이터입니다.\",\n" +
+                "  \"createdTime\": \"2023-05-15T10:30:00\",\n" +
+                "  \"status\": \"ING\",\n" +
+                "  \"takenTime\": 80\n" +
+                "}\n";
+
+        mockMvc.perform(
+                MockMvcRequestBuilders.post("/api/summary/save")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(request))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andDo(print());
+
+    }
+}

--- a/src/test/java/com/knu/KnowcKKnowcK/controller/articleSummary/SaveSummaryControllerTest.java
+++ b/src/test/java/com/knu/KnowcKKnowcK/controller/articleSummary/SaveSummaryControllerTest.java
@@ -1,0 +1,44 @@
+//package com.knu.KnowcKKnowcK.controller.articleSummary;
+//
+//import org.junit.jupiter.api.Test;
+//import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+//import org.springframework.boot.test.context.SpringBootTest;
+//import org.springframework.context.annotation.Configuration;
+//import org.springframework.http.MediaType;
+//import org.springframework.test.web.servlet.MockMvc;
+//import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+//import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+//
+//import static org.junit.jupiter.api.Assertions.*;
+//import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+//
+//@SpringBootTest
+//@AutoConfigureMockMvc
+//class SaveSummaryControllerTest {
+//
+//
+//    @Autowired
+//    private MockMvc mockMvc;
+//
+//    @Test
+//    void saveSummary() throws Exception{
+//
+//        String request = "{\n" +
+//                "  \"articleId\": 1,\n" +
+//                "  \"writerId\": 2,\n" +
+//                "  \"content\": \"이 문서는 더미 데이터입니다.\",\n" +
+//                "  \"createdTime\": \"2023-05-15T10:30:00\",\n" +
+//                "  \"status\": \"PUBLISHED\",\n" +
+//                "  \"takenTime\": 30\n" +
+//                "}\n";
+//
+//        mockMvc.perform(
+//                MockMvcRequestBuilders.post("/api/summary/save")
+//                        .contentType(MediaType.APPLICATION_JSON)
+//                        .content(request))
+//                .andExpect(MockMvcResultMatchers.status().isOk())
+//                .andDo(print());
+//
+//    }
+//}

--- a/src/test/java/com/knu/KnowcKKnowcK/controller/articleSummary/SaveSummaryTest.java
+++ b/src/test/java/com/knu/KnowcKKnowcK/controller/articleSummary/SaveSummaryTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.util.Pair;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -59,7 +60,7 @@ class SaveSummaryTest {
         Mockito.when(articleRepository.findById(any())).thenReturn(Optional.ofNullable(article));
         Mockito.when(memberRepository.findById(any())).thenReturn(Optional.ofNullable(member));
         Mockito.when(summaryRepository.save(any())).thenReturn(summary);
-        Mockito.when(summaryFeedbackService.callGptApi(article.getContent(), summary.getContent())).thenReturn("70#content");
+        Mockito.when(summaryFeedbackService.callGptApi(article.getContent(), summary.getContent())).thenReturn(Pair.of(70,"content"));
         Mockito.when(summaryFeedbackRepository.save(any())).thenReturn(new SummaryFeedback(1L, "content",70, summary));
         SummaryRequestDto summaryRequestDto = new SummaryRequestDto(1L, 1L,
                 summary.getContent(), LocalDateTime.now(), Status.DONE, 100L);
@@ -100,6 +101,24 @@ class SaveSummaryTest {
 
         Assertions.assertThatThrownBy(()->sut.saveSummary(summaryRequestDto)).isInstanceOf(CustomException.class);
     }
+
+    @Test
+    @DisplayName("피드백의 양식이 옳지 않으면 Exception 을 반환한다.")
+    void return_exception_when_invalid_feedback() {
+        Article article = createArticle();
+        Member member = createMember();
+        Summary summary = createSummary(member, article, Status.ING);
+        Mockito.when(articleRepository.findById(any())).thenReturn(Optional.ofNullable(article));
+        Mockito.when(memberRepository.findById(any())).thenReturn(Optional.ofNullable(member));
+        Mockito.when(summaryRepository.save(any())).thenReturn(summary);
+        SummaryRequestDto summaryRequestDto = new SummaryRequestDto(1L, 1L,
+                summary.getContent(), LocalDateTime.now(), Status.ING, 100L);
+
+        SummaryResponseDto summaryResponseDto = sut.saveSummary(summaryRequestDto);
+
+        Assertions.assertThat(summaryResponseDto.getReturnMessage()).isNotNull();
+    }
+
 
     Member createMember(){
         return Member.builder()


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용
- AI 피드백 파싱 메서드를 `SaveSummaryServiceImpl`에서 `ChatGptService` 로 이동시킴 -> 유효성 검사까지 내부에서 완료할 수 있도록 변경
- Dto 자체를 반환하는 대신 **Pair(Integer, String)** 을 사용하여 점수, 피드백을 반환받아 `SaveSummaryService`에서 dto를 구성할 수 있도록 구현
- ❌ (구현안함) : `Summary.save()` 시 Create/Update 구분을 article과 writer로 해야할 것 같다고 판단 (id로 구분 시 존재하는 Summary를 찾아서 id를 불러와야 하는 번거로움) -> Summary에서 `Persistable<Long>` 를 구현하여 `isNew()` 사용으로 해결
- ✅ (구현함) :`Summary` PK를 복합키로 두는 대신 Id로 유지하고 update() 메서드로 업데이트 할 수 있게 구현 ➡️ `Persistable` 가 예상대로 안돌아가서 그냥 하던대로 함 
- 저장돼있는 요약 소요 시간보다 업데이트할 요약 소요시간이 적을 경우 예외처리


<img width="528" alt="스크린샷 2024-04-03 오전 12 27 29" src="https://github.com/KnowckknowcK/BE/assets/90397541/43cbecd7-dd5c-4a73-8b60-545538c03ae0">

---

### ✨ 참고 사항

- Incorrect DNS resolutions on MacOS 해결을 위해 의존성 추가
- `SummaryFeedbackService` 의 parsingFeedback 메서드에서 ChatGPT 양식에 맞게 제대로 응답하여도 예외를 처리함 (이유를 모르겠음) -> 일단 예외 처리 제거
- 당연하겠지만 아직 ChatGPT의 응답이 들쑥날쑥함..
---

### ⏰ 현재 버그
- `Summary.save()` 에서 이미 존재하는 Summary에 대해서 업데이트를 실행하지 않고 새로운 Summary를 생성함 ➡️ 👍 **해결!**
---

### ✏ Git Close #33