### PR TITLE
Fix: 카테고리 추가

### DIFF
--- a/src/main/java/com/knu/KnowcKKnowcK/enums/Category.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/enums/Category.java
@@ -1,5 +1,9 @@
 package com.knu.KnowcKKnowcK.enums;
 
 public enum Category {
-    POLITICS,ECONOMICS,SOCIAL,IT
+    /**
+     * 순서대로 100,101,102,103,104,105,106,107
+     * 110 : OPINION
+     */
+    POLITICS,ECONOMICS,SOCIAL,CULTURE,WORLD,IT,ENTERTAINMENT,SPORT,
 }


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용
- category enum 추가
---

### ✨ 참고 사항

네이버 뉴스 카테고리 분류가 중복되어 나타나는 경우가 있어 카테고리 not found 오류가 생겨 수정하기 위해 추가

---

### ⏰ 현재 버그

ENTERTAINMENT 와 SPORT는 html 구조가 달라 크롤링하지 않음.


---

### ✏ Git Close