### PR TITLE
Feat: 문해력 진단 - 지문 견해 AI 피드백 기능

### DIFF
--- a/src/main/java/com/knu/KnowcKKnowcK/domain/Opinion.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/domain/Opinion.java
@@ -1,0 +1,46 @@
+package com.knu.KnowcKKnowcK.domain;
+
+import com.knu.KnowcKKnowcK.enums.Position;
+import com.knu.KnowcKKnowcK.enums.Status;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Opinion {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(updatable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "article_id")
+    private Article article;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="writer_id")
+    private Member writer;
+
+    @Lob
+    private String content;
+
+    private LocalDateTime createdTime;
+
+    @Enumerated(EnumType.STRING)
+    private Status status;
+
+    private Position position;
+
+    public Opinion update(String content, Status status) {
+        this.content = content;
+        this.status = status;
+
+        return this;
+    }
+}

--- a/src/main/java/com/knu/KnowcKKnowcK/domain/OpinionFeedback.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/domain/OpinionFeedback.java
@@ -1,0 +1,23 @@
+package com.knu.KnowcKKnowcK.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OpinionFeedback {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Lob
+    private String content;
+
+    @OneToOne
+    @JoinColumn(name = "opinion_id")
+    private Opinion opinion;
+}

--- a/src/main/java/com/knu/KnowcKKnowcK/domain/OpinionFeedback.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/domain/OpinionFeedback.java
@@ -15,11 +15,11 @@ public class OpinionFeedback {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
   
+    @Lob
+    private String content;
+
     @JoinColumn(name = "opinion_id")
     @OnDelete(action = OnDeleteAction.CASCADE)
     @OneToOne
     private Opinion opinion;
-  
-    @Lob
-    private String content;
 }

--- a/src/main/java/com/knu/KnowcKKnowcK/dto/requestdto/OpinionRequestDto.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/dto/requestdto/OpinionRequestDto.java
@@ -1,0 +1,46 @@
+package com.knu.KnowcKKnowcK.dto.requestdto;
+
+import com.knu.KnowcKKnowcK.domain.Article;
+import com.knu.KnowcKKnowcK.domain.Member;
+import com.knu.KnowcKKnowcK.domain.Opinion;
+import com.knu.KnowcKKnowcK.enums.Position;
+import com.knu.KnowcKKnowcK.enums.Status;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor(force = true, access = AccessLevel.PROTECTED)
+public class OpinionRequestDto {
+
+    @NotNull(message = "articleId는 null일 수 없습니다.")
+    private Long articleId;
+
+    @NotNull(message = "writerId는 null일 수 없습니다.")
+    private Long writerId;
+
+    @NotNull(message = "내용은 null일 수 없습니다.")
+    private String content;
+
+    private LocalDateTime createdTime;
+
+    @NotNull(message = "상태는 null일 수 없습니다.")
+    private Status status;
+
+    @NotNull(message = "Position은 null일 수 없습니다.")
+    private Position position;
+
+    @Builder
+    public Opinion toEntity(Article article, Member writer) {
+        return Opinion.builder()
+                .article(article)
+                .writer(writer)
+                .content(content)
+                .createdTime(LocalDateTime.now())
+                .status(status)
+                .position(position)
+                .build();
+    }
+}

--- a/src/main/java/com/knu/KnowcKKnowcK/dto/responsedto/OpinionResponseDto.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/dto/responsedto/OpinionResponseDto.java
@@ -1,0 +1,31 @@
+package com.knu.KnowcKKnowcK.dto.responsedto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.knu.KnowcKKnowcK.domain.OpinionFeedback;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
+public class OpinionResponseDto {
+
+    private Long id;
+
+    private String content;
+
+    private String returnMessage;
+
+    private LocalDate localDate;
+
+
+    public OpinionResponseDto(OpinionFeedback feedback){
+        this.id = feedback.getId();
+        this.content = feedback.getContent();
+    }
+
+    public OpinionResponseDto(String msg){
+        this.returnMessage = msg;
+        this.localDate = LocalDate.now();
+    }
+}

--- a/src/main/java/com/knu/KnowcKKnowcK/repository/OpinionFeedbackRepository.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/repository/OpinionFeedbackRepository.java
@@ -1,0 +1,9 @@
+package com.knu.KnowcKKnowcK.repository;
+
+import com.knu.KnowcKKnowcK.domain.OpinionFeedback;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface OpinionFeedbackRepository extends JpaRepository<OpinionFeedback, Long> {
+}

--- a/src/main/java/com/knu/KnowcKKnowcK/repository/OpinionRepository.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/repository/OpinionRepository.java
@@ -1,0 +1,16 @@
+package com.knu.KnowcKKnowcK.repository;
+
+import com.knu.KnowcKKnowcK.domain.Article;
+import com.knu.KnowcKKnowcK.domain.Member;
+import com.knu.KnowcKKnowcK.domain.Opinion;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface OpinionRepository extends JpaRepository<Opinion, Long> {
+
+    Optional<Opinion> findByArticleAndWriter(Article article, Member writer);
+
+}

--- a/src/main/java/com/knu/KnowcKKnowcK/service/articleSummary/SaveOpinionService.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/service/articleSummary/SaveOpinionService.java
@@ -1,0 +1,10 @@
+package com.knu.KnowcKKnowcK.service.articleSummary;
+
+import com.knu.KnowcKKnowcK.dto.requestdto.OpinionRequestDto;
+import com.knu.KnowcKKnowcK.dto.responsedto.OpinionResponseDto;
+
+public interface SaveOpinionService {
+
+    OpinionResponseDto saveOpinion(OpinionRequestDto dto);
+
+}

--- a/src/main/java/com/knu/KnowcKKnowcK/service/articleSummary/SaveOpinionServiceImpl.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/service/articleSummary/SaveOpinionServiceImpl.java
@@ -1,0 +1,64 @@
+package com.knu.KnowcKKnowcK.service.articleSummary;
+
+import com.knu.KnowcKKnowcK.domain.*;
+import com.knu.KnowcKKnowcK.dto.requestdto.OpinionRequestDto;
+import com.knu.KnowcKKnowcK.dto.responsedto.OpinionResponseDto;
+import com.knu.KnowcKKnowcK.enums.Status;
+import com.knu.KnowcKKnowcK.exception.CustomException;
+import com.knu.KnowcKKnowcK.exception.ErrorCode;
+import com.knu.KnowcKKnowcK.repository.*;
+import com.knu.KnowcKKnowcK.service.chatGptService.OpinionFeedbackService;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.util.Pair;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class SaveOpinionServiceImpl  implements SaveOpinionService{
+    private final OpinionRepository opinionRepository;
+
+    private final OpinionFeedbackRepository opinionFeedbackRepository;
+
+    private final ArticleRepository articleRepository;
+
+    private final MemberRepository memberRepository;
+
+    private final OpinionFeedbackService opinionFeedbackService;
+
+    @Override
+    @Transactional
+    public OpinionResponseDto saveOpinion(OpinionRequestDto dto) {
+        Article article = articleRepository.findById(dto.getArticleId()).orElseThrow(()-> new CustomException(ErrorCode.INVALID_INPUT));
+        Member member = memberRepository.findById(dto.getWriterId()).orElseThrow(() -> new CustomException(ErrorCode.INVALID_INPUT));
+        Optional<Opinion> existedOpinion = opinionRepository.findByArticleAndWriter(article, member);
+        Opinion savedOpinion;
+
+        if (existedOpinion.isPresent()){
+            savedOpinion = existedOpinion.get().update(dto.getContent(), dto.getStatus());
+        } else {
+            savedOpinion = opinionRepository.save(dto.toEntity(article, member));
+        }
+
+        if (savedOpinion.getStatus().equals(Status.ING)){
+            return new OpinionResponseDto("임시 저장이 완료되었습니다.");
+
+        } else if (savedOpinion.getStatus().equals(Status.DONE)) {
+            Pair<Integer, String> parsedFeedback = opinionFeedbackService.callGptApi(article.getContent(), savedOpinion.getContent());
+
+            OpinionFeedback opinionFeedback = OpinionFeedback.builder()
+                    .content(parsedFeedback.getSecond())
+                    .opinion(savedOpinion)
+                    .build();
+
+            OpinionFeedback savedFeedback = opinionFeedbackRepository.save(opinionFeedback);
+            return new OpinionResponseDto(savedFeedback);
+
+        } else {
+            throw new CustomException(ErrorCode.FAILED);
+
+        }
+    }
+}

--- a/src/main/java/com/knu/KnowcKKnowcK/service/articleSummary/SaveSummaryServiceImpl.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/service/articleSummary/SaveSummaryServiceImpl.java
@@ -75,5 +75,4 @@ public class SaveSummaryServiceImpl implements SaveSummaryService{
         }
     }
 
-
 }

--- a/src/main/java/com/knu/KnowcKKnowcK/service/chatGptService/OpinionFeedbackService.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/service/chatGptService/OpinionFeedbackService.java
@@ -30,15 +30,6 @@ public class OpinionFeedbackService  implements ChatGptService{
                 .bodyToMono(ChatgptResponseDto.class)
                 .block();
 
-        return parsingFeedback(responseDto.getChoices().get(0).getMessage().getContent());
-    }
-
-    private Pair<Integer, String> parsingFeedback(String content){
-
-        String[] split = content.split("#");
-        int score = Integer.parseInt(split[0]);
-        String feedback = split[1];
-
-        return Pair.of(score, feedback);
+        return Pair.of(1, responseDto.getChoices().get(0).getMessage().getContent());
     }
 }

--- a/src/test/java/com/knu/KnowcKKnowcK/service/articleSummary/SaveOpinionServiceTest.java
+++ b/src/test/java/com/knu/KnowcKKnowcK/service/articleSummary/SaveOpinionServiceTest.java
@@ -1,0 +1,109 @@
+package com.knu.KnowcKKnowcK.service.articleSummary;
+
+import com.knu.KnowcKKnowcK.domain.*;
+import com.knu.KnowcKKnowcK.dto.requestdto.OpinionRequestDto;
+import com.knu.KnowcKKnowcK.dto.responsedto.OpinionResponseDto;
+import com.knu.KnowcKKnowcK.enums.Position;
+import com.knu.KnowcKKnowcK.enums.Status;
+import com.knu.KnowcKKnowcK.repository.*;
+import com.knu.KnowcKKnowcK.service.chatGptService.OpinionFeedbackService;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.util.Pair;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+
+@ExtendWith(MockitoExtension.class)
+class SaveOpinionServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private ArticleRepository articleRepository;
+
+    @Mock
+    private OpinionRepository opinionRepository;
+
+    @InjectMocks
+    private SaveOpinionServiceImpl sut;
+
+    @Mock
+    private OpinionFeedbackService opinionFeedbackService;
+
+    @Mock
+    private OpinionFeedbackRepository opinionFeedbackRepository;
+
+    @Test
+    @DisplayName("견해 자동 제출에 성공하면 임시저장된다.")
+    void saveOpinion_when_auto() {
+        Article article = createArticle();
+        Member member = createMember();
+        Opinion opinion = createOpinion(member, article, Status.ING);
+        Mockito.when(articleRepository.findById(any())).thenReturn(Optional.ofNullable(article));
+        Mockito.when(memberRepository.findById(any())).thenReturn(Optional.ofNullable(member));
+        Mockito.when(opinionRepository.save(any())).thenReturn(opinion);
+        OpinionRequestDto opinionRequestDto = new OpinionRequestDto(1L, 1L,
+                opinion.getContent(), LocalDateTime.now(), Status.DONE, Position.AGREE);
+
+        OpinionResponseDto opinionResponseDto = sut.saveOpinion(opinionRequestDto);
+
+        Assertions.assertThat(opinionResponseDto.getReturnMessage()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("견해 수동 제출에 성공하면 AI 피드백이 반환된다.")
+    void saveOpinion_when_not_auto() {
+        Article article = createArticle();
+        Member member = createMember();
+        Opinion opinion = createOpinion(member, article, Status.DONE);
+        Mockito.when(articleRepository.findById(any())).thenReturn(Optional.ofNullable(article));
+        Mockito.when(memberRepository.findById(any())).thenReturn(Optional.ofNullable(member));
+        Mockito.when(opinionRepository.save(any())).thenReturn(opinion);
+        Mockito.when(opinionFeedbackService.callGptApi(article.getContent(), opinion.getContent())).thenReturn(Pair.of(1,"content"));
+        Mockito.when(opinionFeedbackRepository.save(any())).thenReturn(new OpinionFeedback(1L, "content", opinion));
+        OpinionRequestDto opinionRequestDto = new OpinionRequestDto(1L, 1L,
+                opinion.getContent(), LocalDateTime.now(), Status.DONE, Position.AGREE);
+
+        OpinionResponseDto opinionResponseDto = sut.saveOpinion(opinionRequestDto);
+
+        Assertions.assertThat(opinionResponseDto.getContent()).isEqualTo("content");
+        Assertions.assertThat(opinionResponseDto.getId()).isNotNull();
+    }
+
+    Member createMember(){
+        return Member.builder()
+                .email("email@email.com")
+                .name("member")
+                .profileImage("image.com")
+                .isOAuth(false)
+                .build();
+    }
+
+    Article createArticle(){
+        Article article = new Article();
+        article.setContent("기사내용");
+        return article;
+    }
+
+    Opinion createOpinion(Member member, Article article, Status status){
+        return Opinion.builder()
+                .position(Position.AGREE)
+                .status(status)
+                .writer(member)
+                .article(article)
+                .content("이것은 요약 내용이다.")
+                .id(1L)
+                .createdTime(LocalDateTime.now())
+                .build();
+    }
+}


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용
- `Opinion` 도메인 관련 클래스 추가 (OpinionFeedback, Opinion, OpinionRepository, OpinionFeedbackRepository, OpinionRequestDto, OpinionResponseDto)
- `OpinionFeedbackService`의 Pair<Score, Content> 반환받는 부분에서 Score은 그냥 1 반환시키고 서비스 클래스에서 Score을 따로 사용하지 않는 방향으로 구현함
- `OpinionFeedbackService` 는 피드백을 파싱할 필요가 없으므로 파싱 메서드 제거
- 일단 임시저장을 위해 `Opinion` 도메인에 `Status` 속성 추가함 ➡️  근데 사실 견해는 임시저장이 있는게 기능 흐름 상 자연스러운 것 같진 않습니다
---

### ✨ 참고 사항
- 테스트 완료
- 견해 피드백도 마찬가지로 프롬프트 제작 필요
- @jupyter1234  비슷한 도메인을 다루는 기능이다보니 겹치는 부분(`Opinion.java`, `OpinionFeedback.java` 이 있네요..! 비슷해보여서 고민해보고 둘 중에 선택하면 될 것 같습니다. 일단 이건 내일..)
---

### ⏰ 현재 버그
x
---

### ✏ Git Close #33