### PR TITLE
Feat: 테스트 환경분리 워크플로 수정

### DIFF
--- a/.github/workflows/deployDev.yml
+++ b/.github/workflows/deployDev.yml
@@ -9,7 +9,7 @@ name: Deploy dev branch
 
 on:
   push:
-    branches: [ "dev" ]
+    branches: [ "Test/workflows" ]
 
 
 jobs:

--- a/.github/workflows/deployDev.yml
+++ b/.github/workflows/deployDev.yml
@@ -9,10 +9,73 @@ name: Deploy dev branch
 
 on:
   push:
-    branches: [ "Test/workflows" ]
+    branches: [ "dev" ]
 
 
 jobs:
+  test-build:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    # set up java
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+        # set up .env file
+      - name: Create .env
+        run: |
+          touch ./.env
+          echo "DOCKERHUB_USERNAME=${{ secrets.DOCKERHUB_USERNAME }}" >> ./.env
+          echo "DOCKER_IMAGE=knowckknowck-backend" >> ./.env
+
+        # set up application file
+      - name: Create application file
+        run: |
+          mkdir -p ./src/main/resources
+          cd ./src/main/resources
+          echo "${{ secrets.APPLICATION }}" >> ./application.properties
+          echo "${{ secrets.APPLICATION_TEST }}" >> ./application-test.properties
+          echo "${{ secrets.APPLICATION_PROD }}" >> ./application-prod.properties
+
+        # apply caching
+      - name: Gradle Caching
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      # gradle grant execution permission and build project
+      - name: Setup Gradle
+        run: |
+          chmod +x ./gradlew
+          ./gradlew clean build -Pprofile=prod
+
+      # login dockerhub
+      - name: docker login
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      # build Docker image
+      - name: docker image build
+        run: docker build -t ${{ secrets.DOCKERHUB_USERNAME }}/knowckknowck-backend .
+
+      # push docker image
+      - name: docker Hub push
+        run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/knowckknowck-backend
+
   # run docker image
   run-docker-image-on-server:
     runs-on: ubuntu-latest

--- a/.github/workflows/deployDev.yml
+++ b/.github/workflows/deployDev.yml
@@ -21,77 +21,78 @@ jobs:
 
     # set up java
     steps:
-      - uses: actions/checkout@v4
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
-        with:
-          java-version: '17'
-          distribution: 'temurin'
+    - uses: actions/checkout@v4
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
 
-        # set up .env file
-      - name: Create .env
-        run: |
-          touch ./.env
-          echo "DOCKERHUB_USERNAME=${{ secrets.DOCKERHUB_USERNAME }}" >> ./.env
-          echo "DOCKER_IMAGE=knowckknowck-backend" >> ./.env
+      # set up .env file
+    - name: Create .env
+      run: |
+        touch ./.env
+        echo "DOCKERHUB_USERNAME=${{ secrets.DOCKERHUB_USERNAME }}" >> ./.env
+        echo "DOCKER_IMAGE=knowckknowck-backend" >> ./.env
 
-        # set up application file
-      - name: Create application file
-        run: |
-          mkdir -p ./src/main/resources
-          cd ./src/main/resources
-          echo "${{ secrets.APPLICATION }}" >> ./application.properties
-          echo "${{ secrets.APPLICATION_TEST }}" >> ./application-test.properties
-          echo "${{ secrets.APPLICATION_PROD }}" >> ./application-prod.properties
+      # set up application file
+    - name: Create application file
+      run: |
+        mkdir -p ./src/main/resources
+        cd ./src/main/resources
+        echo "${{ secrets.APPLICATION }}" >> ./application.properties
+        echo "${{ secrets.APPLICATION_TEST }}" >> ./application-test.properties
+        echo "${{ secrets.APPLICATION_PROD }}" >> ./application-prod.properties
 
-        # apply caching
-      - name: Gradle Caching
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
+      # apply caching
+    - name: Gradle Caching
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-
 
-      # gradle grant execution permission and build project
-      - name: Setup Gradle
-        run: |
-          chmod +x ./gradlew
-          ./gradlew clean build -Pprofile=prod
+    # gradle grant execution permission and build project
+    - name: Setup Gradle
+      run: |
+        chmod +x ./gradlew
+        ./gradlew clean build -Pprofile=prod
 
-      # login dockerhub
-      - name: docker login
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+    # login dockerhub
+    - name: docker login
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
-      # build Docker image
-      - name: docker image build
-        run: docker build -t ${{ secrets.DOCKERHUB_USERNAME }}/knowckknowck-backend .
+    # build Docker image
+    - name: docker image build
+      run: docker build -t ${{ secrets.DOCKERHUB_USERNAME }}/knowckknowck-backend .
 
-      # push docker image
-      - name: docker Hub push
-        run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/knowckknowck-backend
+    # push docker image
+    - name: docker Hub push
+      run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/knowckknowck-backend
 
   # run docker image
-  run-docker-image-on-server:
+  deploy:
     runs-on: ubuntu-latest
+    needs: test-build
 
     steps:
-      - name: Deploy Docker image
-        uses: appleboy/ssh-action@master
-        with:
-          host: ${{ secrets.HOST }}
-          username: ${{ secrets.USERNAME }}
-          key: ${{ secrets.PRIVATE_KEY }}
-          port: ${{ secrets.PORT }}
-          script: |
-            sudo docker stop knowckknowck-backend 2>/dev/null || true
-            sudo docker rm knowckknowck-backend
-            sudo docker rmi ${{ secrets.DOCKERHUB_USERNAME }}/knowckknowck-backend
-            sudo docker pull ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKER_IMAGE }}
-            sudo docker-compose up -d
-            sudo docker system prune -f
+    - name: Deploy Docker image
+      uses: appleboy/ssh-action@master
+      with:
+        host: ${{ secrets.HOST }}
+        username: ${{ secrets.USERNAME }}
+        key: ${{ secrets.PRIVATE_KEY }}
+        port: ${{ secrets.PORT }}
+        script: |
+          sudo docker stop knowckknowck-backend 2>/dev/null || true
+          sudo docker rm knowckknowck-backend
+          sudo docker rmi ${{ secrets.DOCKERHUB_USERNAME }}/knowckknowck-backend
+          sudo docker pull ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKER_IMAGE }}
+          sudo docker-compose up -d
+          sudo docker system prune -f

--- a/.github/workflows/deployDev.yml
+++ b/.github/workflows/deployDev.yml
@@ -10,79 +10,25 @@ name: Deploy dev branch
 on:
   push:
     branches: [ "dev" ]
-  pull_request:
-    branches: [ "dev" ]
 
 
 jobs:
-  update-docker-image-push-to-hub:
-    runs-on: ubuntu-latest
-
-    permissions:
-      contents: read
-
-    # set up java
-    steps:
-    - uses: actions/checkout@v4
-    - name: Set up JDK 17
-      uses: actions/setup-java@v4
-      with:
-        java-version: '17'
-        distribution: 'temurin'
-
-      # set up .env file
-    - name: Create .env
-      run: |
-        touch ./.env
-        echo "DOCKERHUB_USERNAME=${{ secrets.DOCKERHUB_USERNAME }}" >> ./.env
-        echo "DOCKER_IMAGE=knowckknowck-backend" >> ./.env
-
-      # set up application file
-    - name: Create application.properties
-      run: |
-        mkdir -p ./src/main/resources
-        cd ./src/main/resources
-        echo "${{ secrets.APPLICATION }}" >> ./application.properties
-
-    # gradle grant execution permission and build project
-    - name: Setup Gradle
-      run: |
-        chmod +x ./gradlew
-        ./gradlew clean build
-
-    # login dockerhub
-    - name: docker login
-      uses: docker/login-action@v2
-      with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
-
-    # build Docker image
-    - name: docker image build
-      run: docker build -t ${{ secrets.DOCKERHUB_USERNAME }}/knowckknowck-backend .
-
-    # push docker image
-    - name: docker Hub push
-      run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/knowckknowck-backend
-
-  
   # run docker image
   run-docker-image-on-server:
     runs-on: ubuntu-latest
-    needs: update-docker-image-push-to-hub
 
     steps:
-    - name: Deploy Docker image
-      uses: appleboy/ssh-action@master
-      with:
-        host: ${{ secrets.HOST }}
-        username: ${{ secrets.USERNAME }}
-        key: ${{ secrets.PRIVATE_KEY }}
-        port: ${{ secrets.PORT }}
-        script: |
-          sudo docker stop knowckknowck-backend 2>/dev/null || true
-          sudo docker rm knowckknowck-backend
-          sudo docker rmi ${{ secrets.DOCKERHUB_USERNAME }}/knowckknowck-backend
-          sudo docker pull ${{ secrets.DOCKERHUB_USERNAME }}/knowckknowck-backend
-          sudo docker-compose up -d
-          sudo docker system prune -f
+      - name: Deploy Docker image
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.USERNAME }}
+          key: ${{ secrets.PRIVATE_KEY }}
+          port: ${{ secrets.PORT }}
+          script: |
+            sudo docker stop knowckknowck-backend 2>/dev/null || true
+            sudo docker rm knowckknowck-backend
+            sudo docker rmi ${{ secrets.DOCKERHUB_USERNAME }}/knowckknowck-backend
+            sudo docker pull ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKER_IMAGE }}
+            sudo docker-compose up -d
+            sudo docker system prune -f

--- a/.github/workflows/testAndBuild.yml
+++ b/.github/workflows/testAndBuild.yml
@@ -5,11 +5,11 @@
 # This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle
 
-name: Deploy dev branch
+name: Test and Build dev branch
 
 on:
   pull_request:
-    branches: [ "dev" ]
+    branches: [ "Test/workflows" ]
 
 
 jobs:

--- a/.github/workflows/testAndBuild.yml
+++ b/.github/workflows/testAndBuild.yml
@@ -1,0 +1,97 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle
+
+name: Deploy dev branch
+
+on:
+  pull_request:
+    branches: [ "dev" ]
+
+
+jobs:
+  update-docker-image-push-to-hub:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    # set up java
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+
+      # set up .env file
+    - name: Create .env
+      run: |
+        touch ./.env
+        echo "DOCKERHUB_USERNAME=${{ secrets.DOCKERHUB_USERNAME }}" >> ./.env
+        echo "DOCKER_IMAGE=knowckknowck-backend" >> ./.env
+
+      # set up application file
+    - name: Create application.properties
+      run: |
+        mkdir -p ./src/main/resources
+        cd ./src/main/resources
+        echo "${{ secrets.APPLICATION }}" >> ./application.properties
+        echo "${{ secrets.APPLICATION_TEST }}" >> ./application-test.properties
+        echo "${{ secrets.APPLICATION_PROD }}" >> ./application-prod.properties
+
+    - name: Setup MySQL
+      uses: mirromutth/mysql-action@v1.1
+      with:
+        host port: 3306
+        container port: 3306
+        mysql database: 'testdb'
+        mysql user: 'test'
+        mysql password: 'test'
+
+    # gradle grant execution permission and build project
+    - name: Setup Gradle
+      run: |
+        chmod +x ./gradlew
+        ./gradlew clean build -Pprofile=test
+
+    # login dockerhub
+    - name: docker login
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+    # build Docker image
+    - name: docker image build
+      run: docker build -t ${{ secrets.DOCKERHUB_USERNAME }}/knowckknowck-backend .
+
+    # push docker image
+    - name: docker Hub push
+      run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/knowckknowck-backend
+
+  
+#  # run docker image
+#  run-docker-image-on-server:
+#    runs-on: ubuntu-latest
+#    needs: update-docker-image-push-to-hub
+#
+#    steps:
+#    - name: Deploy Docker image
+#      uses: appleboy/ssh-action@master
+#      with:
+#        host: ${{ secrets.HOST }}
+#        username: ${{ secrets.USERNAME }}
+#        key: ${{ secrets.PRIVATE_KEY }}
+#        port: ${{ secrets.PORT }}
+#        script: |
+#          sudo docker stop knowckknowck-backend 2>/dev/null || true
+#          sudo docker rm knowckknowck-backend
+#          sudo docker rmi ${{ secrets.DOCKERHUB_USERNAME }}/knowckknowck-backend
+#          sudo docker pull ${{ secrets.DOCKERHUB_USERNAME }}/knowckknowck-backend
+#          sudo docker-compose up -d
+#          sudo docker system prune -f

--- a/.github/workflows/testAndBuild.yml
+++ b/.github/workflows/testAndBuild.yml
@@ -13,7 +13,7 @@ on:
 
 
 jobs:
-  update-docker-image-push-to-hub:
+  test-build:
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/testAndBuild.yml
+++ b/.github/workflows/testAndBuild.yml
@@ -5,7 +5,7 @@
 # This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle
 
-name: Test and Build dev branch
+name: Test dev branch
 
 on:
   pull_request:
@@ -13,7 +13,7 @@ on:
 
 
 jobs:
-  test-build:
+  test:
     runs-on: ubuntu-latest
 
     permissions:
@@ -70,18 +70,4 @@ jobs:
       run: |
         chmod +x ./gradlew
         ./gradlew clean build -Pprofile=test
-
-    # login dockerhub
-    - name: docker login
-      uses: docker/login-action@v2
-      with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
-
-    # build Docker image
-    - name: docker image build
-      run: docker build -t ${{ secrets.DOCKERHUB_USERNAME }}/knowckknowck-backend .
-
-    # push docker image
-    - name: docker Hub push
-      run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/knowckknowck-backend
+        

--- a/.github/workflows/testAndBuild.yml
+++ b/.github/workflows/testAndBuild.yml
@@ -9,7 +9,7 @@ name: Test and Build dev branch
 
 on:
   pull_request:
-    branches: [ "Test/workflows" ]
+    branches: [ "dev" ]
 
 
 jobs:
@@ -36,7 +36,7 @@ jobs:
         echo "DOCKER_IMAGE=knowckknowck-backend" >> ./.env
 
       # set up application file
-    - name: Create application.properties
+    - name: Create application file
       run: |
         mkdir -p ./src/main/resources
         cd ./src/main/resources
@@ -44,6 +44,7 @@ jobs:
         echo "${{ secrets.APPLICATION_TEST }}" >> ./application-test.properties
         echo "${{ secrets.APPLICATION_PROD }}" >> ./application-prod.properties
 
+      # set up mysql
     - name: Setup MySQL
       uses: mirromutth/mysql-action@v1.1
       with:
@@ -52,6 +53,17 @@ jobs:
         mysql database: 'testdb'
         mysql user: 'test'
         mysql password: 'test'
+
+      # apply caching
+    - name: Gradle Caching
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-
 
     # gradle grant execution permission and build project
     - name: Setup Gradle
@@ -73,25 +85,3 @@ jobs:
     # push docker image
     - name: docker Hub push
       run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/knowckknowck-backend
-
-  
-#  # run docker image
-#  run-docker-image-on-server:
-#    runs-on: ubuntu-latest
-#    needs: update-docker-image-push-to-hub
-#
-#    steps:
-#    - name: Deploy Docker image
-#      uses: appleboy/ssh-action@master
-#      with:
-#        host: ${{ secrets.HOST }}
-#        username: ${{ secrets.USERNAME }}
-#        key: ${{ secrets.PRIVATE_KEY }}
-#        port: ${{ secrets.PORT }}
-#        script: |
-#          sudo docker stop knowckknowck-backend 2>/dev/null || true
-#          sudo docker rm knowckknowck-backend
-#          sudo docker rmi ${{ secrets.DOCKERHUB_USERNAME }}/knowckknowck-backend
-#          sudo docker pull ${{ secrets.DOCKERHUB_USERNAME }}/knowckknowck-backend
-#          sudo docker-compose up -d
-#          sudo docker system prune -f

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,6 @@ ARG JAR_FILE=build/libs/*.jar
 
 COPY ${JAR_FILE} app.jar
 
-ENTRYPOINT ["java","-jar","/app.jar"]
+ENTRYPOINT ["java","-Dspring.profiles.active=${PROFILE}","-jar","/app.jar"]
 
 EXPOSE 8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,8 @@ services:
       dockerfile: ./Dockerfile
     ports:
       - 8080:8080
+    environment:
+      PROFILE: prod
     depends_on:
       - redis
     networks:

--- a/src/main/java/com/knu/KnowcKKnowcK/controller/ProfileCheckController.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/controller/ProfileCheckController.java
@@ -1,0 +1,15 @@
+package com.knu.KnowcKKnowcK.controller;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class ProfileCheckController {
+    @Value("${spring.profiles.name}")
+    private String profile;
+    @GetMapping("profile")
+    public String healthyCheck(){
+        return profile;
+    }
+}


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용
- profile을 이용한 테스트, 배포환경 분리
- 도커 런타임시에 실행환경 결정하도록 워크플로 수정
- gradle 캐싱 도입
---

### ✨ 참고 사항
dev 브랜치에 PR 날리면 test, merge되면 test->deploy 되도록 수정

---

### ⏰ 현재 버그

---

### ✏ Git Close
closes #60 