### PR TITLE
Fix: 멤버 생성 시 point, level 초기화

### DIFF
--- a/src/main/java/com/knu/KnowcKKnowcK/domain/Member.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/domain/Member.java
@@ -33,12 +33,14 @@ public class Member {
     private List<Opinion> opinions = new ArrayList<>();
 
     @Builder
-    public Member(String name, String email, String profileImage, Boolean isOAuth, String password) {
+    public Member(String name, String email, String profileImage, Boolean isOAuth, String password, Long point, Long level) {
         this.name = name;
         this.email = email;
         this.profileImage = profileImage;
         this.isOAuth = isOAuth;
         this.password = password;
+        this.point = point;
+        this.level = level;
     }
 
     //프로필 수정

--- a/src/main/java/com/knu/KnowcKKnowcK/service/account/AccountService.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/service/account/AccountService.java
@@ -65,6 +65,8 @@ public class AccountService {
                 .password(passwordEncoder.encode(password))
                 .profileImage(profileImg)
                 .isOAuth(false)
+                .level(0L)
+                .point((0L))
                 .build();
 
         Member savedMember = memberRepository.save(newMember);


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용
- 멤버 생성 시 point, level 초기화
---

### ✨ 참고 사항
- 사소한 수정이라 리뷰 없이 바로 머지 하겠습니다
---

### ⏰ 현재 버그

---

### ✏ Git Close
#101 