### PR TITLE
Feat/issue #116 소셜 로그인 Handler 추가

### DIFF
--- a/src/main/java/com/knu/KnowcKKnowcK/authenticationHandler/CustomAuthenticationFailureHandler.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/authenticationHandler/CustomAuthenticationFailureHandler.java
@@ -1,0 +1,17 @@
+package com.knu.KnowcKKnowcK.authenticationHandler;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+
+import java.io.IOException;
+
+public class CustomAuthenticationFailureHandler implements AuthenticationFailureHandler {
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
+        response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        response.getWriter().write("구글 로그인/회원가입 실패. 관리자에게 문의하세요.");
+    }
+}

--- a/src/main/java/com/knu/KnowcKKnowcK/authenticationHandler/CustomAuthenticationFailureHandler.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/authenticationHandler/CustomAuthenticationFailureHandler.java
@@ -8,10 +8,12 @@ import org.springframework.security.web.authentication.AuthenticationFailureHand
 
 import java.io.IOException;
 
+import static com.knu.KnowcKKnowcK.exception.ErrorCode.OAUTH_LOGIN_FAIL;
+
 public class CustomAuthenticationFailureHandler implements AuthenticationFailureHandler {
     @Override
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
-        response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        response.setStatus(OAUTH_LOGIN_FAIL.getStatus());
         response.getWriter().write("구글 로그인/회원가입 실패. 관리자에게 문의하세요.");
     }
 }

--- a/src/main/java/com/knu/KnowcKKnowcK/authenticationHandler/CustomAuthenticationSuccessHandler.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/authenticationHandler/CustomAuthenticationSuccessHandler.java
@@ -1,0 +1,49 @@
+package com.knu.KnowcKKnowcK.authenticationHandler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.knu.KnowcKKnowcK.utils.JwtUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+public class CustomAuthenticationSuccessHandler implements AuthenticationSuccessHandler {
+    private final Long expiredAt = 1000 * 60 * 60L; //1H
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
+
+        OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+
+        String name = (String) attributes.get("name");
+        String email = (String) attributes.get("email");
+        String profileImg = (String) attributes.get("picture");
+        String accessToken = JwtUtil.creatJWT(email, expiredAt);
+
+        Map<String, String> memberInfo = new HashMap<>();
+        memberInfo.put("name", name);
+        memberInfo.put("email", email);
+        memberInfo.put("profileImg", profileImg);
+        memberInfo.put("token", accessToken);
+
+        // 사용자 정보를 JSON으로 변환
+        ObjectMapper objectMapper = new ObjectMapper();
+        String userJson = objectMapper.writeValueAsString(memberInfo);
+
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        // 사용자 정보를 response 바디에 추가
+        response.getWriter().write(userJson);
+        //상태코드 200
+        response.setStatus(HttpServletResponse.SC_OK);
+    }
+}

--- a/src/main/java/com/knu/KnowcKKnowcK/authenticationHandler/CustomAuthenticationSuccessHandler.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/authenticationHandler/CustomAuthenticationSuccessHandler.java
@@ -13,6 +13,8 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.knu.KnowcKKnowcK.apiResponse.SuccessCode.OK;
+
 @Component
 public class CustomAuthenticationSuccessHandler implements AuthenticationSuccessHandler {
     private final Long expiredAt = 1000 * 60 * 60L; //1H
@@ -44,6 +46,6 @@ public class CustomAuthenticationSuccessHandler implements AuthenticationSuccess
         // 사용자 정보를 response 바디에 추가
         response.getWriter().write(userJson);
         //상태코드 200
-        response.setStatus(HttpServletResponse.SC_OK);
+        response.setStatus(OK.getStatus());
     }
 }

--- a/src/main/java/com/knu/KnowcKKnowcK/authenticationHandler/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/authenticationHandler/JwtAccessDeniedHandler.java
@@ -1,4 +1,4 @@
-package com.knu.KnowcKKnowcK.exception.jwtHandler;
+package com.knu.KnowcKKnowcK.authenticationHandler;
 
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;

--- a/src/main/java/com/knu/KnowcKKnowcK/authenticationHandler/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/authenticationHandler/JwtAccessDeniedHandler.java
@@ -9,11 +9,14 @@ import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 
+import static com.knu.KnowcKKnowcK.exception.ErrorCode.UNAUTHORIZED;
+
 //권한 없는 접근
 @Component
 public class JwtAccessDeniedHandler implements AccessDeniedHandler {
     @Override
     public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
-        response.sendError(HttpServletResponse.SC_FORBIDDEN);
+        response.setStatus(UNAUTHORIZED.getStatus());
+        response.getWriter().write(UNAUTHORIZED.getMessage());
     }
 }

--- a/src/main/java/com/knu/KnowcKKnowcK/authenticationHandler/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/authenticationHandler/JwtAuthenticationEntryPoint.java
@@ -10,10 +10,13 @@ import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 
+import static com.knu.KnowcKKnowcK.exception.ErrorCode.TOKEN_INVALID;
+
 @Component
 public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
-        response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setStatus(TOKEN_INVALID.getStatus());
+        response.getWriter().write(TOKEN_INVALID.getMessage());
     }
 }

--- a/src/main/java/com/knu/KnowcKKnowcK/authenticationHandler/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/authenticationHandler/JwtAuthenticationEntryPoint.java
@@ -1,4 +1,4 @@
-package com.knu.KnowcKKnowcK.exception.jwtHandler;
+package com.knu.KnowcKKnowcK.authenticationHandler;
 
 
 import jakarta.servlet.ServletException;

--- a/src/main/java/com/knu/KnowcKKnowcK/config/WebSecurityConfig.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/config/WebSecurityConfig.java
@@ -1,15 +1,14 @@
 package com.knu.KnowcKKnowcK.config;
 
+import com.knu.KnowcKKnowcK.authenticationHandler.CustomAuthenticationFailureHandler;
+import com.knu.KnowcKKnowcK.authenticationHandler.CustomAuthenticationSuccessHandler;
+import com.knu.KnowcKKnowcK.authenticationHandler.JwtAccessDeniedHandler;
+import com.knu.KnowcKKnowcK.authenticationHandler.JwtAuthenticationEntryPoint;
 import com.knu.KnowcKKnowcK.config.jwtConfig.JwtFilter;
-import com.knu.KnowcKKnowcK.config.jwtConfig.JwtSecurityConfig;
-import com.knu.KnowcKKnowcK.exception.jwtHandler.JwtAccessDeniedHandler;
-import com.knu.KnowcKKnowcK.exception.jwtHandler.JwtAuthenticationEntryPoint;
 import com.knu.KnowcKKnowcK.utils.JwtUtil;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
@@ -56,7 +55,9 @@ public class WebSecurityConfig {
                 .exceptionHandling(exception -> exception
                         .accessDeniedHandler(jwtAccessDeniedHandler)
                         .authenticationEntryPoint(jwtAuthenticationEntryPoint))
-                .oauth2Login(Customizer.withDefaults())
+                .oauth2Login(oauth2Login -> oauth2Login
+                        .successHandler(new CustomAuthenticationSuccessHandler())
+                        .failureHandler(new CustomAuthenticationFailureHandler()))
                 .addFilterBefore(new JwtFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);
 
 

--- a/src/main/java/com/knu/KnowcKKnowcK/controller/AccountController.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/controller/AccountController.java
@@ -34,7 +34,7 @@ public class AccountController {
     private final MailService mailService;
 
 
-    @PostMapping("/google")
+    @GetMapping("/google")
     @Operation(summary = "구글 로그인 및 회원가입 API", description = "구글 로그인 및 회원가입에 대한 API")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "구글 로그인 성공"),

--- a/src/main/java/com/knu/KnowcKKnowcK/controller/AccountController.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/controller/AccountController.java
@@ -34,8 +34,12 @@ public class AccountController {
     private final MailService mailService;
 
 
-    @GetMapping("/google")
+    @PostMapping("/google")
     @Operation(summary = "구글 로그인 및 회원가입 API", description = "구글 로그인 및 회원가입에 대한 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "구글 로그인 성공"),
+            @ApiResponse(responseCode = "400", description = "구글 로그인 실패")
+    })
     public RedirectView redirectToGoogle() {
         RedirectView redirectView = new RedirectView();
         redirectView.setUrl("/oauth2/authorization/google");

--- a/src/main/java/com/knu/KnowcKKnowcK/dto/oauth/OAuthAttributes.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/dto/oauth/OAuthAttributes.java
@@ -11,14 +11,16 @@ import static com.knu.KnowcKKnowcK.service.account.AccountService.MemberPassword
 public class OAuthAttributes {
 
     private Map<String, Object> attributes;
+    private String nameAttributeKey;
     private String name;
     private String email;
     private String profileImg;
 
     @Builder
-    public OAuthAttributes(Map<String, Object> attributes, String name,
+    public OAuthAttributes(Map<String, Object> attributes, String nameAttributeKey, String name,
                            String email, String picture) {
         this.attributes = attributes;
+        this.nameAttributeKey = nameAttributeKey;
         this.name = name;
         this.email = email;
         this.profileImg = picture;
@@ -36,6 +38,7 @@ public class OAuthAttributes {
                 .email((String) attributes.get("email"))
                 .picture((String) attributes.get("picture"))
                 .attributes(attributes)
+                .nameAttributeKey(usernameAttributeName)
                 .build();
     }
 

--- a/src/main/java/com/knu/KnowcKKnowcK/exception/ErrorCode.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/exception/ErrorCode.java
@@ -19,8 +19,10 @@ public enum ErrorCode {
     FAILED_UPLOAD(500, HttpStatus.INTERNAL_SERVER_ERROR,"이미지 업로드에 실패했습니다."),
     FAILED_BATCH(500, HttpStatus.INTERNAL_SERVER_ERROR, "배치 작업에 실패했습니다."),
     FEEDBACK_NOT_EXIST(400, HttpStatus.BAD_REQUEST,"피드백을 받지 않은 요약입니다."),
-    TOKEN_INVALID(401, HttpStatus.UNAUTHORIZED, "유효하지 않은 토근입니다."),
-    TOKEN_EXPIRED(401, HttpStatus.UNAUTHORIZED, "만료된 토큰입니다.");
+    TOKEN_INVALID(401, HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰: 로그인이 필요합니다."),
+    TOKEN_EXPIRED(401, HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
+    UNAUTHORIZED(403, HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+    OAUTH_LOGIN_FAIL(400, HttpStatus.BAD_REQUEST,"소셜 로그인에 실패하였습니다.");
 
     private int status;
     private HttpStatus error;


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용
- success/failure handler 추가
- successHandler에서 로그인 성공 한 사용자 정보 및 jwt 반환
---

### ✨ 참고 사항

---

### ⏰ 현재 버그
- 로컬에서는 매우 잘 작동.. (확인하려면 properties 파일 조작 필요 -> 노션 `.Env -> 백엔드 로컬용` 참고)
- 배포환경 redirectionUrl 추가 후 작동이 되었다가 또 안되기 시작함.. 이것저것 노력해보겠습니다🥲

---

### ✏ Git Close
#116 
