### PR TITLE
Fix: AI 요약 피드백 트랜잭션 이슈

### DIFF
--- a/src/main/java/com/knu/KnowcKKnowcK/service/articleSummary/SaveSummaryServiceImpl.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/service/articleSummary/SaveSummaryServiceImpl.java
@@ -56,7 +56,6 @@ public class SaveSummaryServiceImpl implements SaveSummaryService{
 
 
     @Override
-    @Transactional(readOnly=true)
     public SummaryResponseDto getSummaryFeedback(SummaryRequestDto dto, String writer) {
         if (dto.getStatus() != Status.DONE)
             throw new CustomException(ErrorCode.INVALID_INPUT);
@@ -67,6 +66,7 @@ public class SaveSummaryServiceImpl implements SaveSummaryService{
 
         return new SummaryResponseDto(saveSummaryFeedback(dto.toEntity(article, member),parsedFeedback));
     }
+
 
 
     @Transactional


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용
 - 메서드 분리도 이미 다 돼있길래 그냥 @transactional 옵션에서 readOnly만 뺌
---

### ✨ 참고 사항
 - 메서드가 분리돼있다 하더라도 **create를 하는  transactional 한 메서드가 readOnly 메서드 내부에서 실행되기 때문에** readOnly 옵션을 위반했고 그래서 에러가 나는게 아닐까 싶음
- 에러 로그 : `java.sql.SQLException: Connection is read-only. Queries leading to data modification are not allowed`
- 그리고 제가 해결방법을 못찾았을 수 있는데.. 외부 api 가 트랜잭션에 영향을 줄 때 이를 개선할 수 있는 경우는 **외부 api가 DB 처리에 영향이 없는 경우** 아닌가요? 이 기능은 외부 api 의 결과가 DB로 들어가야하니 트랜잭션 분리 등의 개선이 가능한지 잘 모르겠습니다.. 확실치 않아서 의견 주시면 좋겠습니당
---

### ⏰ 현재 버그

---

### ✏ Git Close #131