### PR TITLE
Fix/issue #135

### DIFF
--- a/src/main/java/com/knu/KnowcKKnowcK/domain/Opinion.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/domain/Opinion.java
@@ -1,13 +1,11 @@
 package com.knu.KnowcKKnowcK.domain;
 
 import com.knu.KnowcKKnowcK.enums.Position;
-import com.knu.KnowcKKnowcK.enums.Status;
 import jakarta.persistence.*;
 import lombok.*;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
-
 import java.time.LocalDateTime;
 
 @Entity
@@ -34,18 +32,9 @@ public class Opinion {
     @Enumerated(EnumType.STRING)
     private Position position;
   
-    @Enumerated(EnumType.STRING)
-    private Status status;
-  
     private LocalDateTime createdTime;
 
     @Column(length = 3000)
     private String feedbackContent;
 
-    public Opinion update(String content, Status status) {
-      this.content = content;
-      this.status = status;
-
-      return this;
-    }
 }

--- a/src/main/java/com/knu/KnowcKKnowcK/dto/requestdto/OpinionRequestDto.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/dto/requestdto/OpinionRequestDto.java
@@ -1,16 +1,10 @@
 package com.knu.KnowcKKnowcK.dto.requestdto;
-
-import com.knu.KnowcKKnowcK.domain.Article;
-import com.knu.KnowcKKnowcK.domain.Member;
-import com.knu.KnowcKKnowcK.domain.Opinion;
 import com.knu.KnowcKKnowcK.enums.Position;
-import com.knu.KnowcKKnowcK.enums.Status;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
-
 import java.time.LocalDateTime;
 
-@Data
+@Getter
 @AllArgsConstructor
 @NoArgsConstructor(force = true, access = AccessLevel.PROTECTED)
 public class OpinionRequestDto {
@@ -18,26 +12,11 @@ public class OpinionRequestDto {
     @NotNull(message = "articleId는 null일 수 없습니다.")
     private Long articleId;
 
-
     @NotNull(message = "내용은 null일 수 없습니다.")
     private String content;
 
     private LocalDateTime createdTime;
 
-    @NotNull(message = "상태는 null일 수 없습니다.")
-    private Status status;
-
     @NotNull(message = "Position은 null일 수 없습니다.")
     private Position position;
-
-    @Builder
-    public Opinion toEntity(Article article) {
-        return Opinion.builder()
-                .article(article)
-                .content(content)
-                .createdTime(LocalDateTime.now())
-                .status(status)
-                .position(position)
-                .build();
-    }
 }

--- a/src/main/java/com/knu/KnowcKKnowcK/dto/responsedto/article/ArticleListResponseDto.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/dto/responsedto/article/ArticleListResponseDto.java
@@ -20,9 +20,11 @@ public class ArticleListResponseDto {
     private LocalDateTime createdTime;
     private String articleUrl;
     private boolean isSummaryDone;
+    private boolean isOpinionDone;
+
 
     @Builder
-    private ArticleListResponseDto(Long id, String title, Category category,String content, LocalDateTime createdTime, String articleUrl, boolean isSummaryDone){
+    private ArticleListResponseDto(Long id, String title, Category category,String content, LocalDateTime createdTime, String articleUrl, boolean isSummaryDone, boolean isOpinionDone){
         this.id = id;
         this.title = title;
         this.category = category;
@@ -30,9 +32,10 @@ public class ArticleListResponseDto {
         this.articleUrl = articleUrl;
         this.createdTime = createdTime;
         this.isSummaryDone = isSummaryDone;
+        this.isOpinionDone = isOpinionDone;
     }
 
-    public static ArticleListResponseDto from(Article article, boolean isSummaryDone){
+    public static ArticleListResponseDto from(Article article, boolean isSummaryDone, boolean isOpinionDone){
         return ArticleListResponseDto.builder()
                 .id(article.getId())
                 .title(article.getTitle())
@@ -41,6 +44,7 @@ public class ArticleListResponseDto {
                 .createdTime(article.getCreatedTime())
                 .articleUrl(article.getArticleUrl())
                 .isSummaryDone(isSummaryDone)
+                .isOpinionDone(isOpinionDone)
                 .build();
     }
 }

--- a/src/main/java/com/knu/KnowcKKnowcK/exception/ErrorCode.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/exception/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
     INVALID_PERMISSION(401,HttpStatus.UNAUTHORIZED, "권한이 없습니다"),
     INVALID_INPUT(400, HttpStatus.BAD_REQUEST,"잘못된 요청입니다."),
     ALREADY_REGISTERED(409, HttpStatus.CONFLICT,"이미 가입된 회원입니다."),
+    ALREADY_EXISTED(409, HttpStatus.CONTINUE, "이미 피드백 받은 내용이 존재합니다."),
     OAUTH_MEMBER(409, HttpStatus.CONFLICT,"소셜 로그인 가입 회원입니다."),
     FAILED_UPLOAD(500, HttpStatus.INTERNAL_SERVER_ERROR,"이미지 업로드에 실패했습니다."),
     FAILED_BATCH(500, HttpStatus.INTERNAL_SERVER_ERROR, "배치 작업에 실패했습니다."),

--- a/src/main/java/com/knu/KnowcKKnowcK/service/articleOpinion/SaveOpinionServiceImpl.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/service/articleOpinion/SaveOpinionServiceImpl.java
@@ -38,7 +38,7 @@ public class SaveOpinionServiceImpl  implements SaveOpinionService{
         Optional<Opinion> existedOpinion = opinionRepository.findByArticleAndWriter(article, member);
 
          if (existedOpinion.isPresent()) {
-             throw new CustomException(ErrorCode.INVALID_INPUT);
+             throw new CustomException(ErrorCode.ALREADY_EXISTED);
          }
 
         Pair<Score, String> feedback = chatGptContext.callGptApi(Option.OPINION, article.getContent(), dto.getContent());

--- a/src/main/java/com/knu/KnowcKKnowcK/service/articleOpinion/SaveOpinionServiceImpl.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/service/articleOpinion/SaveOpinionServiceImpl.java
@@ -48,7 +48,6 @@ public class SaveOpinionServiceImpl  implements SaveOpinionService{
                 .content(dto.getContent())
                 .writer(member)
                 .article(article)
-                .status(Status.DONE)
                 .position(dto.getPosition())
                 .build();
 

--- a/src/main/java/com/knu/KnowcKKnowcK/service/articleSummary/LoadArticlesServiceImpl.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/service/articleSummary/LoadArticlesServiceImpl.java
@@ -5,6 +5,7 @@ import com.knu.KnowcKKnowcK.domain.Member;
 import com.knu.KnowcKKnowcK.domain.Summary;
 import com.knu.KnowcKKnowcK.dto.responsedto.article.ArticleListResponseDto;
 import com.knu.KnowcKKnowcK.enums.Category;
+import com.knu.KnowcKKnowcK.enums.Status;
 import com.knu.KnowcKKnowcK.exception.CustomException;
 import com.knu.KnowcKKnowcK.exception.ErrorCode;
 import com.knu.KnowcKKnowcK.repository.ArticleRepository;
@@ -45,12 +46,11 @@ public class LoadArticlesServiceImpl implements LoadArticlesService{
 
         Page<ArticleListResponseDto> articlesResponse = articles.map(article -> {
             Optional<Summary> summary = summaryRepository.findByArticleAndWriter(article, member);
-            return ArticleListResponseDto.from(article, summary.isPresent());
+            return ArticleListResponseDto.from(article, summary.isPresent() && summary.get().getStatus().equals(Status.DONE));
 
         });
 
         return articlesResponse;
-
     }
 
     @Override

--- a/src/main/java/com/knu/KnowcKKnowcK/service/articleSummary/LoadArticlesServiceImpl.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/service/articleSummary/LoadArticlesServiceImpl.java
@@ -2,6 +2,7 @@ package com.knu.KnowcKKnowcK.service.articleSummary;
 
 import com.knu.KnowcKKnowcK.domain.Article;
 import com.knu.KnowcKKnowcK.domain.Member;
+import com.knu.KnowcKKnowcK.domain.Opinion;
 import com.knu.KnowcKKnowcK.domain.Summary;
 import com.knu.KnowcKKnowcK.dto.responsedto.article.ArticleListResponseDto;
 import com.knu.KnowcKKnowcK.enums.Category;
@@ -10,6 +11,7 @@ import com.knu.KnowcKKnowcK.exception.CustomException;
 import com.knu.KnowcKKnowcK.exception.ErrorCode;
 import com.knu.KnowcKKnowcK.repository.ArticleRepository;
 import com.knu.KnowcKKnowcK.repository.MemberRepository;
+import com.knu.KnowcKKnowcK.repository.OpinionRepository;
 import com.knu.KnowcKKnowcK.repository.SummaryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -17,6 +19,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -34,7 +37,10 @@ public class LoadArticlesServiceImpl implements LoadArticlesService{
 
     private final MemberRepository memberRepository;
 
+    private final OpinionRepository opinionRepository;
+
     @Override
+    @Transactional(readOnly = true)
     public Page<ArticleListResponseDto> loadArticles(Category category, int page, String memberEmail) {
 
         Member member = memberRepository.findByEmail(memberEmail).orElseThrow(() -> new CustomException(USER_NOT_FOUND));
@@ -46,10 +52,13 @@ public class LoadArticlesServiceImpl implements LoadArticlesService{
 
         Page<ArticleListResponseDto> articlesResponse = articles.map(article -> {
             Optional<Summary> summary = summaryRepository.findByArticleAndWriter(article, member);
-            return ArticleListResponseDto.from(article, summary.isPresent() && summary.get().getStatus().equals(Status.DONE));
+            Optional<Opinion> opinion = opinionRepository.findByArticleAndWriter(article, member);
 
+            return ArticleListResponseDto.from(article,
+                    summary.isPresent() && summary.get().getStatus().equals(Status.DONE),
+                    opinion.isPresent()
+                    );
         });
-
         return articlesResponse;
     }
 

--- a/src/main/java/com/knu/KnowcKKnowcK/service/articleSummary/SaveSummaryServiceImpl.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/service/articleSummary/SaveSummaryServiceImpl.java
@@ -39,17 +39,19 @@ public class SaveSummaryServiceImpl implements SaveSummaryService{
     @Override
     @Transactional
     public SummaryResponseDto saveSummary(SummaryRequestDto dto, String writer) {
+        if(!dto.getStatus().equals(Status.ING)){
+            throw new CustomException(ErrorCode.INVALID_INPUT);
+        }
+
         Article article = articleRepository.findById(dto.getArticleId()).orElseThrow(()-> new CustomException(ErrorCode.INVALID_INPUT));
         Member member = memberRepository.findByEmail(writer).orElseThrow(() -> new CustomException(ErrorCode.INVALID_INPUT));
+        summaryRepository.findByArticleAndWriter(article,member);
+
         summaryRepository.findByArticleAndWriter(article, member)
                 .ifPresentOrElse(
                 summary -> summary.update(dto.getContent(), dto.getStatus(), dto.getTakenTime()),
                 () -> summaryRepository.save(dto.toEntity(article, member))
                 );
-
-        if(!dto.getStatus().equals(Status.ING)){
-            throw new CustomException(ErrorCode.INVALID_INPUT);
-        }
 
         return new SummaryResponseDto("임시 저장이 완료되었습니다.");
     }
@@ -59,6 +61,7 @@ public class SaveSummaryServiceImpl implements SaveSummaryService{
     public SummaryResponseDto getSummaryFeedback(SummaryRequestDto dto, String writer) {
         if (dto.getStatus() != Status.DONE)
             throw new CustomException(ErrorCode.INVALID_INPUT);
+
         Article article = articleRepository.findById(dto.getArticleId()).orElseThrow(()-> new CustomException(ErrorCode.INVALID_INPUT));
         Member member = memberRepository.findByEmail(writer).orElseThrow(() -> new CustomException(ErrorCode.INVALID_INPUT));
 

--- a/src/test/java/com/knu/KnowcKKnowcK/service/articleOpinion/SaveOpinionTest.java
+++ b/src/test/java/com/knu/KnowcKKnowcK/service/articleOpinion/SaveOpinionTest.java
@@ -13,7 +13,6 @@ import com.knu.KnowcKKnowcK.repository.ArticleRepository;
 import com.knu.KnowcKKnowcK.repository.MemberRepository;
 import com.knu.KnowcKKnowcK.repository.OpinionRepository;
 import com.knu.KnowcKKnowcK.service.chatGptService.ChatGptContext;
-import com.knu.KnowcKKnowcK.service.chatGptService.OpinionFeedbackClient;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -55,7 +54,7 @@ class SaveOpinionTest {
         Mockito.when(articleRepository.findById(any())).thenReturn(Optional.ofNullable(article));
         Mockito.when(memberRepository.findByEmail(any())).thenReturn(Optional.of(member));
         Mockito.when(opinionRepository.findByArticleAndWriter(any(), any())).thenReturn(Optional.empty());
-        OpinionRequestDto requestDto = new OpinionRequestDto(1L, "content", LocalDateTime.now(), Status.DONE, Position.AGREE);
+        OpinionRequestDto requestDto = new OpinionRequestDto(1L, "content", LocalDateTime.now(), Position.AGREE);
         Mockito.when(chatGptContext.callGptApi(Option.OPINION, article.getContent(), requestDto.getContent())).thenReturn((Pair<Score, String>) Pair.of(Score.EXCELLENT,"아주 좋아요."));
 
         OpinionResponseDto opinionFeedback = sut.getOpinionFeedback(requestDto, member.getEmail());

--- a/src/test/java/com/knu/KnowcKKnowcK/service/articleSummary/LoadArticlesServiceTest.java
+++ b/src/test/java/com/knu/KnowcKKnowcK/service/articleSummary/LoadArticlesServiceTest.java
@@ -2,12 +2,15 @@ package com.knu.KnowcKKnowcK.service.articleSummary;
 
 import com.knu.KnowcKKnowcK.domain.Article;
 import com.knu.KnowcKKnowcK.domain.Member;
+import com.knu.KnowcKKnowcK.domain.Opinion;
 import com.knu.KnowcKKnowcK.domain.Summary;
 import com.knu.KnowcKKnowcK.dto.responsedto.article.ArticleListResponseDto;
 import com.knu.KnowcKKnowcK.enums.Category;
+import com.knu.KnowcKKnowcK.enums.Position;
 import com.knu.KnowcKKnowcK.enums.Status;
 import com.knu.KnowcKKnowcK.repository.ArticleRepository;
 import com.knu.KnowcKKnowcK.repository.MemberRepository;
+import com.knu.KnowcKKnowcK.repository.OpinionRepository;
 import com.knu.KnowcKKnowcK.repository.SummaryRepository;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -42,6 +45,9 @@ class LoadArticlesServiceTest {
     @Mock
     private SummaryRepository summaryRepository;
 
+    @Mock
+    private OpinionRepository opinionRepository;
+
     @Test
     @DisplayName("지문 목록 조회에 성공하고 해당 기사의 요약을 진행했을 경우 summaryDone = True가 나온다.")
     void loadArticles() {
@@ -49,6 +55,7 @@ class LoadArticlesServiceTest {
         Member member = createMember();
         Article article = createArticle("기사 예시");
         Summary summary = createSummary(member, article, Status.DONE);
+        Opinion opinion = createOpinion(article, member);
         Page<Article> page = createPage();
         List<Sort.Order> sorts = new ArrayList<>();
         sorts.add(Sort.Order.asc("createdTime"));
@@ -57,11 +64,13 @@ class LoadArticlesServiceTest {
                 .thenReturn(page);
         Mockito.when(memberRepository.findByEmail(any())).thenReturn(Optional.of(member));
         Mockito.when(summaryRepository.findByArticleAndWriter(any(), any())).thenReturn(Optional.of(summary));
+        Mockito.when(opinionRepository.findByArticleAndWriter(any(), any())).thenReturn(Optional.of(opinion));
 
         Page<ArticleListResponseDto> loaded = sut.loadArticles(Category.CULTURE, pageNum, "admin");
 
         Assertions.assertThat(loaded.getTotalElements()).isEqualTo(7);
         Assertions.assertThat(loaded.getContent().get(0).isSummaryDone()).isEqualTo(true);
+        Assertions.assertThat(loaded.getContent().get(0).isOpinionDone()).isEqualTo(true);
     }
 
     Article createArticle(String title){
@@ -108,9 +117,12 @@ class LoadArticlesServiceTest {
                 .build();
     }
 
-    Article createArticle(){
-        Article article = new Article();
-        article.setContent("기사내용");
-        return article;
+    Opinion createOpinion(Article article, Member member){
+        return Opinion.builder()
+                .position(Position.AGREE)
+                .article(article)
+                .writer(member)
+                .content("string")
+                .build();
     }
 }


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용
- Status가 `DONE` 인지 확인을 해서 요약 완료 구분을 함
- 기사 목록 조회 시 견해 작성 여부도 확인할 수 있도록 함
- ErrorCode 추가
- `Opinion`의 `status` 필드 삭제 ➡️ @jupyter1234 견해 조회 부분에 영향 가는 부분이 있으면 알려주세요 거기까지 반영해두겠습니당
- `OpinionRequestDto` 빌더, `@Data` 삭제
---

### ✨ 궁금한 사항
- 완료된 요약 피드백이 있는  기사에 대해 다시 문해력 진단을 하려고 하면 오류가 나야하는데 지금처럼 DB integrity 오류가 알아서 나도록 두는게 좋은지, 이것도 서비스 단에서 미리 예외 처리를 하는게 좋은지 궁금함

---

### ⏰ 현재 버그

---

### ✏ Git Close