### PR TITLE
Fix/issue #143 회원가입/로그인 관련 오류 수정

### DIFF
--- a/src/main/java/com/knu/KnowcKKnowcK/controller/AccountController.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/controller/AccountController.java
@@ -85,7 +85,8 @@ public class AccountController {
             @ApiResponse(responseCode = "400", description = "회원가입 실패"),
             @ApiResponse(responseCode = "409", description = "회원가입 실패: 이미 가입 된 email")
     })
-    public ApiResponseDto<String> signupWithEmail(@RequestPart("userInfo") String userInfo, @RequestPart("profileImg") MultipartFile profileImg) throws JsonProcessingException {
+    public ApiResponseDto<String> signupWithEmail(@RequestPart("userInfo") String userInfo,
+                                                   @RequestPart(value = "profileImg", required = false) MultipartFile profileImg) throws JsonProcessingException {
         HttpStatus response = accountService.signupWithEmail(userInfo, profileImg);
 
         if (response.equals(ALREADY_REGISTERED.getError()))

--- a/src/main/java/com/knu/KnowcKKnowcK/dto/oauth/OAuthAttributes.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/dto/oauth/OAuthAttributes.java
@@ -49,6 +49,8 @@ public class OAuthAttributes {
                 .profileImage(profileImg)
                 .password(generateRandomPassword(10))
                 .isOAuth(true)
+                .level(0L)
+                .point(0L)
                 .build();
     }
 }

--- a/src/main/java/com/knu/KnowcKKnowcK/service/account/AccountService.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/service/account/AccountService.java
@@ -24,6 +24,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.security.SecureRandom;
 import java.util.Optional;
+import java.util.Random;
 
 import static com.knu.KnowcKKnowcK.apiResponse.SuccessCode.CREATED_SUCCESS;
 import static com.knu.KnowcKKnowcK.exception.ErrorCode.ALREADY_REGISTERED;
@@ -64,6 +65,8 @@ public class AccountService {
 
     public HttpStatus signupWithEmail(String userInfo, MultipartFile profileImg) throws JsonProcessingException {
 
+        String profileImgUrl = "";
+
         ObjectMapper objectMapper = new ObjectMapper();
         SignupRequestDto requestDto = objectMapper.readValue(userInfo, SignupRequestDto.class);
 
@@ -72,7 +75,13 @@ public class AccountService {
         if (member.isPresent())
             return ALREADY_REGISTERED.getError();
 
-        String profileImgUrl = awsS3Util.uploadFile(profileImg);
+        if (profileImg == null || profileImg.isEmpty()) {
+            profileImgUrl = randomDefaultImg();
+        }
+        else{
+            profileImgUrl = awsS3Util.uploadFile(profileImg);
+        }
+
 
         Member newMember = Member.builder()
                 .email(requestDto.getEmail())
@@ -98,6 +107,21 @@ public class AccountService {
                     .jwt(JwtUtil.creatJWT(email, expiredAt))
                     .build();
         }
+    }
+
+    public String randomDefaultImg() {
+
+        String[] defaultImg = {
+                "https://knowckknowck-bucket.s3.ap-northeast-2.amazonaws.com/profile/profile1.png",
+                "https://knowckknowck-bucket.s3.ap-northeast-2.amazonaws.com/profile/profile2.png",
+                "https://knowckknowck-bucket.s3.ap-northeast-2.amazonaws.com/profile/profile3.png",
+                "https://knowckknowck-bucket.s3.ap-northeast-2.amazonaws.com/profile/profile4.png"
+        };
+
+        Random random = new Random();
+        int imgNumber = random.nextInt(4);
+
+        return defaultImg[imgNumber];
     }
 
     public class MemberPasswordGenerator {

--- a/src/main/java/com/knu/KnowcKKnowcK/service/account/UserDetailsServiceImpl.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/service/account/UserDetailsServiceImpl.java
@@ -25,10 +25,6 @@ public class UserDetailsServiceImpl implements UserDetailsService {
         Member member = memberRepository.findByEmail(username)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        if (member.getIsOAuth()) {
-            throw new CustomException(ErrorCode.OAUTH_MEMBER);
-        }
-
         Set<GrantedAuthority> grantedAuthorities = new HashSet<>(); //권한 지정하지 않음
 
         return new org


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용
-  구글 로그인 후, "유효하지 않은 토큰"오류 해결
- 구글 회원가입 사용자 레벨, 포인트 초기화
- 이메일 회원가입 시 프로필 이미지 선택(required = false)으로 수정
- 프로필 이미지 null인 경우 랜덤 디폴트 이미지 저장
- 구글 가입 회원이 이메일 로그인 시도 예외 처리
---

### ✨ 참고 사항

---

### ⏰ 현재 버그
이메일 가입 회원이 구글 로그인 시도 예외 처리 -> domain.Member.summaries: could not initialize proxy - no Session

---

### ✏ Git Close