### PR TITLE
Refactor/issue #152 토론방 로직 JPQL 사용

### DIFF
--- a/src/main/java/com/knu/KnowcKKnowcK/domain/DebateRoom.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/domain/DebateRoom.java
@@ -5,6 +5,8 @@ import lombok.*;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 
+import java.util.List;
+
 @Entity
 @Data
 @NoArgsConstructor
@@ -23,10 +25,12 @@ public class DebateRoom {
     private Long disagreeNum;
     private Long disagreeLikesNum;
 
+    @OneToMany(mappedBy = "debateRoom", fetch = FetchType.LAZY)
+    private List<MemberDebate> memberDebates;
 
     @Builder
     public DebateRoom(Article article){
-        this.id = article.getId();  // 애초에 기사-토론방은 1대1 관계라 id 필드가 필요 없었을 거 같아요.
+        this.id = article.getId();
         this.article = article;
         this.title = article.getTitle();
         this.agreeNum = 0L;

--- a/src/main/java/com/knu/KnowcKKnowcK/domain/Message.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/domain/Message.java
@@ -11,6 +11,7 @@ import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static com.knu.KnowcKKnowcK.service.debateRoom.DebateRoomUtil.formatToLocalDateTime;
 
@@ -37,6 +38,12 @@ public class Message {
     private String content;
     private LocalDateTime createdTime;
     private Position position;
+
+    @OneToMany(mappedBy = "message", fetch = FetchType.LAZY)
+    private List<MessageThread> messageThreads;
+
+    @OneToMany(mappedBy = "message", fetch = FetchType.LAZY)
+    private List<Preference> preferences;
 
     public MessageResponseDto toMessageResponseDto(long likesNum, long threadNum, String profileImage){
         return MessageResponseDto.builder()

--- a/src/main/java/com/knu/KnowcKKnowcK/repository/DebateRoomRepository.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/repository/DebateRoomRepository.java
@@ -1,8 +1,12 @@
 package com.knu.KnowcKKnowcK.repository;
 
 import com.knu.KnowcKKnowcK.domain.DebateRoom;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface DebateRoomRepository extends JpaRepository<DebateRoom, Long> {
-    boolean existsByArticleId(Long id);
+    @EntityGraph(attributePaths = {"memberDebates"})
+    Optional<DebateRoom> findById(Long id);
 }

--- a/src/main/java/com/knu/KnowcKKnowcK/repository/MemberDebateRepository.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/repository/MemberDebateRepository.java
@@ -4,6 +4,8 @@ import com.knu.KnowcKKnowcK.domain.DebateRoom;
 import com.knu.KnowcKKnowcK.domain.Member;
 import com.knu.KnowcKKnowcK.domain.MemberDebate;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -12,5 +14,7 @@ public interface MemberDebateRepository extends JpaRepository<MemberDebate, Long
     Optional<MemberDebate> findByMemberAndDebateRoom(Member member, DebateRoom debateRoom);
 
     List<MemberDebate> findAllByMember(Member member);
-    List<MemberDebate> findByDebateRoom(DebateRoom debateRoom);
+
+    @Query("SELECT md FROM MemberDebate md WHERE md.member.id = :memberId AND md.debateRoom.id = :debateRoomId")
+    Optional<MemberDebate> findByMemberIdAndDebateRoomId(@Param("memberId") Long memberId, @Param("debateRoomId") Long debateRoomId);
 }

--- a/src/main/java/com/knu/KnowcKKnowcK/repository/MessageRepository.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/repository/MessageRepository.java
@@ -3,11 +3,26 @@ package com.knu.KnowcKKnowcK.repository;
 
 import com.knu.KnowcKKnowcK.domain.DebateRoom;
 import com.knu.KnowcKKnowcK.domain.Message;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 
 public interface MessageRepository extends JpaRepository<Message, Long> {
     List<Message> findByDebateRoom(DebateRoom debateRoom);
+    @Query("SELECT m, COUNT(mt), COUNT(p), m.member.profileImage " +
+            "FROM Message m " +
+            "LEFT JOIN m.messageThreads mt " +
+            "LEFT JOIN m.preferences p " +
+            "WHERE m.debateRoom = :debateRoom " +
+            "GROUP BY m.id, m.member.profileImage")
+    List<Object[]> findMessagesWithCounts(@Param("debateRoom") DebateRoom debateRoom);
+
+
+    @Query("SELECT m FROM Message m LEFT JOIN FETCH m.messageThreads WHERE m.id = :id")
+    Optional<Message> findByIdWithMessageThreads(@Param("id") Long id);
 }

--- a/src/main/java/com/knu/KnowcKKnowcK/repository/MessageRepository.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/repository/MessageRepository.java
@@ -22,7 +22,9 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
             "GROUP BY m.id, m.member.profileImage")
     List<Object[]> findMessagesWithCounts(@Param("debateRoom") DebateRoom debateRoom);
 
-
-    @Query("SELECT m FROM Message m LEFT JOIN FETCH m.messageThreads WHERE m.id = :id")
-    Optional<Message> findByIdWithMessageThreads(@Param("id") Long id);
+    @Query("SELECT m FROM Message m " +
+            "LEFT JOIN FETCH m.messageThreads " +
+            "LEFT JOIN FETCH m.member " +
+            "WHERE m.id = :id")
+    Optional<Message> findByIdWithMessageThreadsAndMember(@Param("id") Long id);
 }

--- a/src/main/java/com/knu/KnowcKKnowcK/repository/MessageRepository.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/repository/MessageRepository.java
@@ -3,7 +3,6 @@ package com.knu.KnowcKKnowcK.repository;
 
 import com.knu.KnowcKKnowcK.domain.DebateRoom;
 import com.knu.KnowcKKnowcK.domain.Message;
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;

--- a/src/main/java/com/knu/KnowcKKnowcK/service/debateRoom/DebateRoomService.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/service/debateRoom/DebateRoomService.java
@@ -100,8 +100,9 @@ public class DebateRoomService {
         DebateRoom debateRoom = debateRoomRepository.findById(debateRoomId)
                 .orElseThrow(() -> new CustomException(ErrorCode.INVALID_INPUT));
 
-        return makeDebateRoomMemberList(memberDebateRepository.findByDebateRoom(debateRoom));
+        return makeDebateRoomMemberList(debateRoom.getMemberDebates());
     }
+
 
     private Position decidePosition(double ratio){
         // 비율에 따른 찬/반 결정

--- a/src/test/java/com/knu/KnowcKKnowcK/service/debateRoom/DebateRoomSetUp.java
+++ b/src/test/java/com/knu/KnowcKKnowcK/service/debateRoom/DebateRoomSetUp.java
@@ -9,9 +9,11 @@ import com.knu.KnowcKKnowcK.repository.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -49,6 +51,7 @@ public abstract class DebateRoomSetUp {
     protected Long roomId;
     protected Message message;
 
+    protected List<MessageThread> threadList;
     @BeforeEach
     protected void setUp(){
         // 테스트에 사용될 객체 초기화
@@ -62,7 +65,7 @@ public abstract class DebateRoomSetUp {
         preferenceRequestDto = createPreferenceRequestDto();
         preference = preferenceRequestDto.toPreference(member, message);
         MessageThread thread = threadDto.toMessageThread(member, message, memberDebate.getPosition());
-        List<MessageThread> threadList = new ArrayList<>();
+        threadList = new ArrayList<>();
         threadList.add(thread);
         List<Preference> preferenceList = new ArrayList<>();
         preferenceList.add(preference);

--- a/src/test/java/com/knu/KnowcKKnowcK/service/debateRoom/MessageServiceTest.java
+++ b/src/test/java/com/knu/KnowcKKnowcK/service/debateRoom/MessageServiceTest.java
@@ -27,6 +27,8 @@ class MessageServiceTest extends DebateRoomSetUp{
     @Test
     @DisplayName("토론방 메세지를 적절한 형태로 가공하여 보내는 지 검증하는 테스트")
     void saveAndReturnMessage() {
+        when(memberDebateRepository.findByMemberIdAndDebateRoomId(member.getId(), debateRoom.getId())).thenReturn(Optional.ofNullable(memberDebate));
+
         // 메소드 실행
         MessageResponseDto result = messageService.saveAndReturnMessage(member, messageDto);
 
@@ -40,6 +42,7 @@ class MessageServiceTest extends DebateRoomSetUp{
     @Test
     @DisplayName("토론방 메세지 스레드를 적절한 형태로 가공하여 보내는 지 검증하는 테스트")
     void saveAndReturnMessageThread() {
+        when(memberDebateRepository.findByMemberIdAndDebateRoomId(member.getId(), debateRoom.getId())).thenReturn(Optional.ofNullable(memberDebate));
         // 메소드 실행
         MessageThreadResponseDto result = messageService.saveAndReturnMessageThread(member, message.getId(),threadDto);
 

--- a/src/test/java/com/knu/KnowcKKnowcK/service/debateRoom/MessageServiceTest.java
+++ b/src/test/java/com/knu/KnowcKKnowcK/service/debateRoom/MessageServiceTest.java
@@ -9,7 +9,9 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import static com.knu.KnowcKKnowcK.service.debateRoom.DebateRoomUtil.getDebateRoomKey;
 import static com.knu.KnowcKKnowcK.service.debateRoom.DebateRoomUtil.getMessageThreadKey;
@@ -51,17 +53,27 @@ class MessageServiceTest extends DebateRoomSetUp{
     @Test
     @DisplayName("메세지 리스트를 제대로 받아오는 지 검증하는 테스트")
     public void getMessagesSuccess() {
+        Object[] mockResult = new Object[]{message, 1L, 1L, member.getProfileImage()};
+
+        List<Object[]> mockResults = new ArrayList<>();
+        mockResults.add(mockResult);
+
+        when(messageRepository.findMessagesWithCounts(debateRoom)).thenReturn(mockResults);
         // 메소드 실행
         List<MessageResponseDto> result = messageService.getMessages(roomId);
 
         // 검증
         assertThat(result.size()).isEqualTo(1);
         assertThat(result.get(0).getContent()).isEqualTo(message.getContent());
+        assertThat(result.get(0).getThreadNum()).isEqualTo(1);
+        assertThat(result.get(0).getLikesNum()).isEqualTo(1);
         verify(redisUtil, times(1)).getDataList(getDebateRoomKey(debateRoom.getId()), MessageResponseDto.class);
     }
     @Test
     @DisplayName("메세지 스레드 리스트를 제대로 받아오는 지 검증하는 테스트")
     public void getMessageThreadDtoList() {
+        message.setMessageThreads(threadList);
+        when(messageRepository.findByIdWithMessageThreadsAndMember(message.getId())).thenReturn(Optional.ofNullable(message));
         // 메소드 실행
         List<MessageThreadResponseDto> result = messageService.getMessageThreadDtoList(message.getId());
 


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용
- Message 조회 시 MessageThread 및 Preference 수를 JPQL로 계산하여 가져옴
- Message 조회 시 Member 및 MessageThread를 JPQL로 같이 가져옴
- DebateRoom 조회 시 MemberDebateList도 같이 가져옴 
- MemberDebate 조회 시 DebateRoom도 같이 가져옴
- 위를 활용해 토론방 로직 개선
---

### ✨ 참고 사항

쿼리 수가 얼마나 줄었는 지는 노션/트러블 및 공부한 내용에 있는 jpql 활용했을 경우의 성능 향상 페이지를 참고해주세요.

---

### ⏰ 현재 버그

---

### ✏ Git Close
#152 