### PR TITLE
Refac/issue #158

### DIFF
--- a/src/main/java/com/knu/KnowcKKnowcK/domain/Member.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/domain/Member.java
@@ -55,4 +55,9 @@ public class Member {
         this.name = name;
         this.password = password;
     }
+
+    public Member updatePoint(Long point){
+        this.point += point;
+        return this;
+    }
 }

--- a/src/main/java/com/knu/KnowcKKnowcK/repository/MemberRepository.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/repository/MemberRepository.java
@@ -1,11 +1,17 @@
 package com.knu.KnowcKKnowcK.repository;
 
 import com.knu.KnowcKKnowcK.domain.Member;
+import com.knu.KnowcKKnowcK.exception.CustomException;
+import com.knu.KnowcKKnowcK.exception.ErrorCode;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
-
     Optional<Member> findByEmail(String email);
+
+    default Member getUserByEmail(String email) {
+        return this.findByEmail(email).orElseThrow(
+                () -> new CustomException(ErrorCode.USER_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/knu/KnowcKKnowcK/service/summary/SummaryFeedbackService.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/service/summary/SummaryFeedbackService.java
@@ -1,0 +1,37 @@
+package com.knu.KnowcKKnowcK.service.summary;
+
+import com.knu.KnowcKKnowcK.domain.Member;
+import com.knu.KnowcKKnowcK.domain.Summary;
+import com.knu.KnowcKKnowcK.domain.SummaryFeedback;
+import com.knu.KnowcKKnowcK.enums.Score;
+import com.knu.KnowcKKnowcK.repository.MemberRepository;
+import com.knu.KnowcKKnowcK.repository.SummaryFeedbackRepository;
+import com.knu.KnowcKKnowcK.repository.SummaryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.util.Pair;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class SummaryFeedbackService {
+    private final SummaryRepository summaryRepository;
+
+    private final SummaryFeedbackRepository summaryFeedbackRepository;
+
+    private final MemberRepository memberRepository;
+
+
+    @Transactional
+    public SummaryFeedback saveSummaryFeedback(Summary summary, Pair<Score, String> parsedFeedback, Member member){
+        summaryRepository.findByArticleAndWriter(summary.getArticle(), member)
+                .ifPresent(summaryRepository::delete);
+        summaryRepository.flush();
+        Summary savedSummary = summaryRepository.save(summary);
+
+        member.setPoint(member.getPoint() + parsedFeedback.getFirst().getExp());
+        memberRepository.save(member);
+
+        return summaryFeedbackRepository.save(SummaryFeedback.from(savedSummary,parsedFeedback));
+    }
+}


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용
- Transactional self-invocation 오류 수정
- member 쪽 코드 리팩토링
---

### ✨ 참고 사항

@adorableco 
1. member point 업데이트를 위해 모든 필드에 대해 setter 가 허용되어있는데 point에만 접근할 수 있는 public 메서드를 추가하는 방법으로 수정하면 어떨까요 . 해당 메서드는 Member클래스에 추가해 뒀습니다.(서비스 로직에는 아직 반영 안함)
2. member not found exception 던지는 곳이 너무 중복으로 발생해서 메서드로 분리해두었습니다. 우선은 summary save 메서드에만 적용
3. self-invocation 오류 수정을 위해 SummaryFeedback 클래스 분리
4. article관련 클래스랑 summary 관련 클래스를 분리하는게 어떨까요 



---

### ⏰ 현재 버그

---

### ✏ Git Close
closes #158 