### PR TITLE
Fix: Opinion createdTime 이 null 로 들어가는 오류

### DIFF
--- a/src/main/java/com/knu/KnowcKKnowcK/service/opinion/OpinionService.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/service/opinion/OpinionService.java
@@ -14,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.util.Pair;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 @Service
@@ -46,6 +47,7 @@ public class OpinionService{
                 .writer(member)
                 .article(article)
                 .position(dto.getPosition())
+                .createdTime(LocalDateTime.now())
                 .build();
 
         opinionRepository.save(opinion);


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용
- opinionFeedback 생성시 createdTime을 넣지 않음 (알려주셔서 감사해요...^^..)
- createdTime이 null 이라 대시보드에서 NullPointerException이 걸려 오류 발생
---

### ✨ 참고 사항

---

### ⏰ 현재 버그 

---

### ✏ Git Close #162 