### PR TITLE
Fix: AI 피드백 응답 잘림

### DIFF
--- a/src/main/java/com/knu/KnowcKKnowcK/dto/requestdto/chatGpt/ChatgptRequestDto.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/dto/requestdto/chatGpt/ChatgptRequestDto.java
@@ -12,8 +12,8 @@ public class ChatgptRequestDto implements Serializable {
     private List<Message> messages = new ArrayList<>();
 
     private String model = "gpt-3.5-turbo";
-    @JsonProperty("max_tokens")
-    private Integer maxTokens = 100;
+//    @JsonProperty("max_tokens")
+//    private Integer maxTokens = 200;
 
 //    private Double temperature=1.0;
 //    @JsonProperty("stop")


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용
- `ChatgptRequestDto` 에서 `maxTokens` 를 주석 처리함
---

### ✨ 참고 사항
- maxToken 이 100으로 계속 적용돼있던 것 같음

- 일단 maxToken 필드를 아예 없앴는데 max값을 늘리는 쪽으로 수정해도 될 듯함

---

### ⏰ 현재 버그

---

### ✏ Git Close #165 