### PR TITLE
Fix: 장문 메세지 잘리는 현상 수정

### DIFF
--- a/src/main/java/com/knu/KnowcKKnowcK/domain/Message.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/domain/Message.java
@@ -35,6 +35,7 @@ public class Message {
     @OnDelete(action = OnDeleteAction.CASCADE)
     private Member member;
 
+    @Column(length = 10000)
     private String content;
     private LocalDateTime createdTime;
     private Position position;

--- a/src/main/java/com/knu/KnowcKKnowcK/domain/MessageThread.java
+++ b/src/main/java/com/knu/KnowcKKnowcK/domain/MessageThread.java
@@ -32,6 +32,7 @@ public class MessageThread {
     @OnDelete(action = OnDeleteAction.CASCADE)
     private Member member;
 
+    @Column(length = 10000)
     private String content;
     private LocalDateTime createdTime;
     private Position position;


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용
- 장문 메세지가 db에 저장되지 못하는 현상 수정
---

### ✨ 참고 사항

db는 초기화 대신 sql로 직접 수정할 예정입니다.

---

### ⏰ 현재 버그

---

### ✏ Git Close